### PR TITLE
grepWin is now hosted on SF

### DIFF
--- a/automatic/grepwin/grepwin.ketarin.xml
+++ b/automatic/grepwin/grepwin.ketarin.xml
@@ -4,8 +4,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>598016</LastFileSize>
-    <LastFileDate>2013-05-04T08:45:40.3797091</LastFileDate>
+    <LastFileSize>626688</LastFileSize>
+    <LastFileDate>2014-06-17T20:13:59+02:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -26,9 +26,9 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://code.google.com/feeds/p/grepwin/downloads/basic</Url>
-            <StartText>href="http://code.google.com/p/grepwin/downloads/detail?name=grepWin-</StartText>
-            <EndText>-64.msi</EndText>
+            <Url>http://sourceforge.net/projects/stefanstools/files/grepWin/</Url>
+            <StartText>&lt;tr title="</StartText>
+            <EndText>" class="folder "&gt;</EndText>
             <TextualContent />
             <Name>version</Name>
           </UrlVariable>
@@ -44,23 +44,24 @@
             <VariableType>Textual</VariableType>
             <Regex>http://code.google.com/feeds/p/grepwin/downloads/basic/grepWin-\d+\.\d+.\d+\-64.msi</Regex>
             <Url>http://code.google.com/feeds/p/grepwin/downloads/basic</Url>
-            <TextualContent>http://grepwin.googlecode.com/files/grepWin-{version}-64.msi</TextualContent>
+            <TextualContent>http://sourceforge.net/projects/stefanstools/files/grepWin/{version}/grepWin-{version}-64.msi/download</TextualContent>
             <Name>url64</Name>
           </UrlVariable>
         </value>
       </item>
       <item>
         <key>
-          <string>urlpart</string>
+          <string>mirror</string>
         </key>
         <value>
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
-            <VariableType>Textual</VariableType>
+            <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://code.google.com/feeds/p/grepwin/downloads/basic/grepWin-1.5.7-64.msi</Url>
-            <TextualContent>grepWin-{version}</TextualContent>
-            <Name>urlpart</Name>
+            <Url>http://sourceforge.net/projects/stefanstools/files/grepWin/1.6.5/grepWin-1.6.5.msi/download</Url>
+            <StartText>;use_mirror=</StartText>
+            <EndText>"&gt;</EndText>
+            <Name>mirror</Name>
           </UrlVariable>
         </value>
       </item>
@@ -71,13 +72,13 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\grepWin-1.6.1.msi</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\grepWin-1.6.5.msi</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2013-05-04T08:45:40.3797091</LastUpdated>
+    <LastUpdated>2014-08-06T19:43:11.1609116+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://grepwin.googlecode.com/files/{urlpart}.msi</FixedDownloadUrl>
+    <FixedDownloadUrl>http://{mirror}.dl.sourceforge.net/project/stefanstools/grepWin/{version}/grepWin-{version}.msi</FixedDownloadUrl>
     <Name>grepwin</Name>
   </ApplicationJob>
 </Jobs>

--- a/automatic/grepwin/tools/chocolateyInstall.ps1
+++ b/automatic/grepwin/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-Install-ChocolateyPackage 'grepwin' 'msi' '/quiet' '{{DownloadUrl}}' '{{DownloadUrlx64}}' 
+Install-ChocolateyPackage 'grepwin' 'msi' '/quiet' 'http://sourceforge.net/projects/stefanstools/files/grepWin/{{PackageVersion}}/grepWin-{{PackageVersion}}.msi/download' '{{DownloadUrlx64}}'


### PR DESCRIPTION
Argh, another developer who switched from that Google Code crap to that SF crap. :worried:

Your package is stuck at v1.6.3. grepWin 1.6.5 is the latest version. This PR fixes the package and makes it use the new download location.

Tested & working.
