### PR TITLE
Fix AHK script for Dropbox for other locales

### DIFF
--- a/automatic/dropbox/tools/dropbox.ahk
+++ b/automatic/dropbox/tools/dropbox.ahk
@@ -3,7 +3,10 @@
 SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
 SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
 
-WinWait, Dropbox Setup,, 60
+; A window's title can contain WinTitle anywhere inside it to be a match.
+SetTitleMatchMode, 2
+
+WinWait, Dropbox ahk_class #32770, , 60
 Sleep, 2000
 WinActivate
 IfWinActive


### PR DESCRIPTION
Better i18n compatibility for the package: this should fix the issue with languages where Dropbox’s installer has a different window title than `Dropbox Setup`.

Now it matches any window that contains _Dropbox_ in the title **and** which has the class `ahk_class #32770`. I’ve noticed that the window class remains the same across multiple computers and Windows versions, so I think it’s safe to use it. I hope that this is strict enough to not accidentally match the wrong window.
