### PR TITLE
Use .tools/ folder of package as destination for optipng binaries, fix optipng’s Ketarin job

### DIFF
--- a/automatic/OptiPNG/OptiPNG.ketarin.xml
+++ b/automatic/OptiPNG/OptiPNG.ketarin.xml
@@ -1,8 +1,7 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
 <Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="a0d2737d-8359-4f0c-a663-e94bea185f9d">
-    <SourceTemplate><![CDATA[<?xml version="1.0" encoding="utf-8"?>
-<Jobs>
+    <SourceTemplate><![CDATA[<Jobs>
   <ApplicationJob xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Guid="0fb30714-8ed0-4611-8f1b-cb8fec9dae91">
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
@@ -72,8 +71,8 @@
     <WebsiteUrl />
     <UserAgent>Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19</UserAgent>
     <UserNotes />
-    <LastFileSize>137421</LastFileSize>
-    <LastFileDate>2012-10-22T03:41:00+02:00</LastFileDate>
+    <LastFileSize>137247</LastFileSize>
+    <LastFileDate>2014-03-24T11:45:00+01:00</LastFileDate>
     <IgnoreFileInformation>false</IgnoreFileInformation>
     <DownloadBeta>Default</DownloadBeta>
     <DownloadDate xsi:nil="true" />
@@ -116,6 +115,22 @@
           </UrlVariable>
         </value>
       </item>
+      <item>
+        <key>
+          <string>mirror</string>
+        </key>
+        <value>
+          <UrlVariable>
+            <RegexRightToLeft>false</RegexRightToLeft>
+            <VariableType>StartEnd</VariableType>
+            <Regex />
+            <Url>http://sourceforge.net/projects/optipng/files/OptiPNG/optipng-{version}/optipng-{version}-win32.zip/download</Url>
+            <StartText>;use_mirror=</StartText>
+            <EndText>"&gt;</EndText>
+            <Name>mirror</Name>
+          </UrlVariable>
+        </value>
+      </item>
     </Variables>
     <ExecuteCommand />
     <ExecutePreCommand />
@@ -123,13 +138,13 @@
     <ExecutePreCommandType>Batch</ExecutePreCommandType>
     <Category />
     <SourceType>FixedUrl</SourceType>
-    <PreviousLocation>C:\Chocolatey\_work\optipng-0.7.4-win32.zip</PreviousLocation>
+    <PreviousLocation>C:\Chocolatey\_work\optipng-0.7.5-win32.zip</PreviousLocation>
     <DeletePreviousFile>true</DeletePreviousFile>
     <Enabled>true</Enabled>
     <FileHippoId />
-    <LastUpdated>2013-08-02T13:25:50.4677312+02:00</LastUpdated>
+    <LastUpdated>2014-08-09T16:21:20.7838961+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://freefr.dl.sourceforge.net/project/optipng/OptiPNG/optipng-{version}/optipng-{version}-win32.zip</FixedDownloadUrl>
+    <FixedDownloadUrl>http://{mirror}.dl.sourceforge.net/project/optipng/OptiPNG/optipng-{version}/optipng-{version}-win32.zip</FixedDownloadUrl>
     <Name>OptiPNG</Name>
   </ApplicationJob>
 </Jobs>

--- a/automatic/OptiPNG/tools/chocolateyInstall.ps1
+++ b/automatic/OptiPNG/tools/chocolateyInstall.ps1
@@ -1,21 +1,14 @@
-try {
+﻿try {
   $package = 'OptiPNG'
-  $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" 
-  ### For BinRoot, use the following instead ###
-  $binRoot = "$env:systemdrive\"
-  ### Using an environment variable to to define the bin root until we implement configuration ###
-  if($env:chocolatey_bin_root -ne $null){$binRoot = join-path $env:systemdrive $env:chocolatey_bin_root}
-  $installDir = Join-Path $binRoot $package
-  Write-Host "Adding `'$installDir`' to the path and the current shell path"
-  Install-ChocolateyPath "$installDir"
-  $env:Path = "$($env:Path);$installDir"
+  $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
   $zipUrl = 'http://sourceforge.net/projects/optipng/files/OptiPNG/optipng-{{PackageVersion}}/optipng-{{PackageVersion}}-win32.zip/download'
 
   Install-ChocolateyZipPackage $package "$zipUrl" "$installDir"
 
-  Copy-Item "$($installDir)\optipng-{{PackageVersion}}-win32\*" "$installDir" -Force -Recurse
-  
-  Write-ChocolateySuccess $package
+  Move-Item -Path "$($installDir)\optipng-{{PackageVersion}}-win32\*" -Destination "$installDir" -Force
+  Remove-Item "$($installDir)\optipng-{{PackageVersion}}-win32"
+
 } catch {
   Write-ChocolateyFailure $package "$($_.Exception.Message)"
   throw


### PR DESCRIPTION
I’m not really a fan of putting things directly into the root of the system drive (like this package previously did with `C:\OptiPNG`).

Why not put it into the `./tools` folder of the package? Then it is also not necessary to add stuff to the PATH variable, because SihmGen already handles it.

In addition your Ketarin job for optipng was broken (SourceForge again).

As soon as you merge this, don’t forget to release the fixed version of this package (e.g. v0.7.5.201408…).
