### PR TITLE
Adapt package titles to be compliant with the guidelines

### DIFF
--- a/automatic/7zip.commandline/7zip.commandline.nuspec
+++ b/automatic/7zip.commandline/7zip.commandline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>7zip.commandline</id>
-    <title>7Zip (CommandLine)</title>
+    <title>7-Zip (CommandLine)</title>
     <version>{{PackageVersion}}</version>
     <authors>Igor Pavlov</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/7zip.install/7zip.install.nuspec
+++ b/automatic/7zip.install/7zip.install.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>7zip.install</id>
-    <title>7Zip (Install)</title>
+    <title>7-Zip (Install)</title>
     <version>{{PackageVersion}}</version>
     <authors>Igor Pavlov</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/7zip/7zip.nuspec
+++ b/automatic/7zip/7zip.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>7zip</id>
-    <title>7Zip</title>
+    <title>7-Zip</title>
     <version>{{PackageVersion}}</version>
     <authors>Igor Pavlov</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/OptiPNG/OptiPNG.nuspec
+++ b/automatic/OptiPNG/OptiPNG.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>OptiPNG</id>
-    <title>OptiPNG : Advanced PNG Optimizer</title>
+    <title>OptiPNG: Advanced PNG Optimizer</title>
     <version>{{PackageVersion}}</version>
     <authors>Cosmin Truta</authors>
     <owners>Ethan Brown, Rob Reynolds</owners>

--- a/automatic/adobereader/adobereader.nuspec
+++ b/automatic/adobereader/adobereader.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>adobereader</id>
-    <title>AdobeReader</title>
+    <title>Adobe Reader</title>
     <version>{{PackageVersion}}</version>
     <authors>Adobe</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/attributechanger/attributechanger.nuspec
+++ b/automatic/attributechanger/attributechanger.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>attributechanger</id>
-    <title>AttributeChanger</title>
+    <title>Attribute Changer</title>
     <version>{{PackageVersion}}</version>
     <authors>Romain Petges</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/filezilla.server/filezilla.server.nuspec
+++ b/automatic/filezilla.server/filezilla.server.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>filezilla.server</id>
-    <title>FileZilla.Server</title>
+    <title>FileZilla Server</title>
     <version>{{PackageVersion}}</version>
     <authors>Tim Kosse, other FileZilla committers</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/gitextensions/gitextensions.nuspec
+++ b/automatic/gitextensions/gitextensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>gitextensions</id>
-    <title>GitExtensions</title>
+    <title>Git Extensions</title>
     <version>{{PackageVersion}}</version>
     <authors>Henk Westhuis</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/nmap/nmap.nuspec
+++ b/automatic/nmap/nmap.nuspec
@@ -3,6 +3,7 @@
   <metadata>
     <id>nmap</id>
     <version>{{PackageVersion}}</version>
+    <title>Nmap</title>
     <authors>Fyodor</authors>
     <owners>zippy1981 ferventcoder</owners>
     <licenseUrl>http://nmap.org/svn/COPYING</licenseUrl>

--- a/automatic/pip/pip.nuspec
+++ b/automatic/pip/pip.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>{{PackageName}}</id>
-    <title>Pip(Python) Installs Packages</title>
+    <title>Pip (Python) Installs Packages</title>
     <version>{{PackageVersion}}</version>
     <authors>The Pip developers</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/sliksvn/sliksvn.nuspec
+++ b/automatic/sliksvn/sliksvn.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>{{PackageName}}</id>
     <version>{{PackageVersion}}</version>
-    <title>SlikSVN</title>
+    <title>Slik SVN</title>
     <authors>Slik Company</authors>
     <projectUrl>http://www.sliksvn.com/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/ferventcoder/chocolatey-packages/master/icons/sliksvn.png</iconUrl>

--- a/automatic/sqlite.analyzer/sqlite.analyzer.nuspec
+++ b/automatic/sqlite.analyzer/sqlite.analyzer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>{{PackageName}}</id>
-    <title>SQLite.analyzer</title>
+    <title>SQLite Analyzer</title>
     <version>{{PackageVersion}}</version>
     <authors>D. Richard Hipp, SQLite contributors</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/sqlite.shell/sqlite.shell.nuspec
+++ b/automatic/sqlite.shell/sqlite.shell.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>{{PackageName}}</id>
-    <title>SQLite.shell</title>
+    <title>SQLite Shell</title>
     <version>{{PackageVersion}}</version>
     <authors>D. Richard Hipp, SQLite contributors</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/sqliteadmin/sqliteadmin.nuspec
+++ b/automatic/sqliteadmin/sqliteadmin.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>{{PackageName}}</id>
-    <title>SQLiteAdmin</title>
+    <title>SQLite Administrator</title>
     <version>{{PackageVersion}}</version>
     <authors>Orbmu2k</authors>
     <owners>Rob Reynolds</owners>

--- a/automatic/vlc/vlc.nuspec
+++ b/automatic/vlc/vlc.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>vlc</id>
-    <title>VLC</title>
+    <title>VLC media player</title>
     <version>{{PackageVersion}}</version>
     <authors>VideoLAN Organization</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/boutdutunnel.client/boutdutunnel.client.nuspec
+++ b/manual/boutdutunnel.client/boutdutunnel.client.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>boutdutunnel.client</id>
-    <title>BoutDuTunnel.Client</title>
+    <title>BoutDuTunnel Client</title>
     <version>1.5.3369.20120226</version>
     <authors>Sebastien LEBRETON</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/boutdutunnel.server/boutdutunnel.server.nuspec
+++ b/manual/boutdutunnel.server/boutdutunnel.server.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>boutdutunnel.server</id>
-    <title>BoutDuTunnel.Server</title>
+    <title>BoutDuTunnel Server</title>
     <version>1.5.3369.20120225</version>
     <authors>Sebastien LEBRETON</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/fluffyapp/fluffyapp.nuspec
+++ b/manual/fluffyapp/fluffyapp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>fluffyapp</id>
-    <title>fluffyapp</title>
+    <title>FluffyApp</title>
     <version>2.0.3</version>
     <authors>Richard Z.H. Wang</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/instanteyedropper.app/instanteyedropper.app.nuspec
+++ b/manual/instanteyedropper.app/instanteyedropper.app.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>instanteyedropper.app</id>
-    <title>instanteyedropper (Application Install)</title>
+    <title>Instant Eyedropper (Application Install)</title>
     <version>1.75</version>
     <authors>SpiceBrains.com</authors>
     <owners>Rob Reynolds</owners>
     <summary>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.</summary>
-    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click. 
-    
+    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.
+
     Identifying the color code of an object on the screen is usually an involved, multistep process: You press the Print Screen key to copy a screenshot to the clipboard, load a graphics-editing program, create a new file, paste the screenshot from the clipboard, zoom in on the object, use the "Pick Color" tool, and finally copy the HTML code of the color to the clipboard.
 
     Webmasters may repeat this operation many times a day. Just imagine how much time can be saved by using Instant Eyedropper to do the same thing with a Single Click!

--- a/manual/instanteyedropper.tool/instanteyedropper.tool.nuspec
+++ b/manual/instanteyedropper.tool/instanteyedropper.tool.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>instanteyedropper.tool</id>
-    <title>instanteyedropper (Non-installed Tool)</title>
+    <title>Instant Eyedropper (Non-installed Tool)</title>
     <version>1.75</version>
     <authors>SpiceBrains.com</authors>
     <owners>Rob Reynolds</owners>
     <summary>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.</summary>
-    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click. 
-    
+    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.
+
     Identifying the color code of an object on the screen is usually an involved, multistep process: You press the Print Screen key to copy a screenshot to the clipboard, load a graphics-editing program, create a new file, paste the screenshot from the clipboard, zoom in on the object, use the "Pick Color" tool, and finally copy the HTML code of the color to the clipboard.
 
     Webmasters may repeat this operation many times a day. Just imagine how much time can be saved by using Instant Eyedropper to do the same thing with a Single Click!

--- a/manual/instanteyedropper/instanteyedropper.nuspec
+++ b/manual/instanteyedropper/instanteyedropper.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>instanteyedropper</id>
-    <title>instanteyedropper</title>
+    <title>Instant Eyedropper</title>
     <version>1.75</version>
     <authors>SpiceBrains.com</authors>
     <owners>Rob Reynolds</owners>
     <summary>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.</summary>
-    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click. 
-    
+    <description>Instant Eyedropper is a free software tool for webmasters that will identify and automatically paste to the clipboard the HTML color code of any pixel on the screen with just a single mouse click.
+
     Identifying the color code of an object on the screen is usually an involved, multistep process: You press the Print Screen key to copy a screenshot to the clipboard, load a graphics-editing program, create a new file, paste the screenshot from the clipboard, zoom in on the object, use the "Pick Color" tool, and finally copy the HTML code of the color to the clipboard.
 
     Webmasters may repeat this operation many times a day. Just imagine how much time can be saved by using Instant Eyedropper to do the same thing with a Single Click!

--- a/manual/setaffinity2/setaffinity2.nuspec
+++ b/manual/setaffinity2/setaffinity2.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>setaffinity2</id>
-    <title>setaffinity2</title>
+    <title>Set Affinity II</title>
     <version>1.041.20140616</version>
     <authors>Edgemeal Software</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/webpicmd/webpicmd.nuspec
+++ b/manual/webpicmd/webpicmd.nuspec
@@ -6,7 +6,7 @@
     <version>7.1.50430.0</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>
-    <summary>WebPI (Platform Installer) Command Line v5</summary>
+    <summary>Web PI (Platform Installer) Command Line v5</summary>
     <description>The Microsoft Web Platform Installer (Web PI) Command Line v5 makes it easy for you to download, install, and keep up to date on the latest software components of the Microsoft Web Platform for development and application hosting on the Windows operating system. Web PI does the work of comparing the newest available components across the Microsoft Web Platform against what is already installed on your computer; you can see what is new and what you haven't yet installed. You can use Web PI to learn more about different components and install one or more components in a chained installation, with Web PI handling reboots and logging failures where applicable.
     </description>
     <projectUrl>http://www.iis.net/learn/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release</projectUrl>

--- a/manual/webpicommandline/webpicommandline.nuspec
+++ b/manual/webpicommandline/webpicommandline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>webpicommandline</id>
-    <title>WebPICommandLine</title>
+    <title>Web PI CommandLine</title>
     <version>7.1.40719.0</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/windowsphonedevelopertools/windowsphonedevelopertools.nuspec
+++ b/manual/windowsphonedevelopertools/windowsphonedevelopertools.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>windowsphonedevelopertools</id>
-    <title>WindowsPhoneDeveloperTools</title>
+    <title>Windows Phone Developer Tools</title>
     <version>1.0</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>


### PR DESCRIPTION
This PR makes at least the `<title>` compliant with the [package naming guidelines](https://github.com/chocolatey/chocolatey/wiki/CreatePackages#naming-your-package).
