### PR TITLE
git.install: Do not specify /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS

### DIFF
--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 try {
-  Install-ChocolateyPackage 'git.install' 'exe' '/VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /NOICONS  /COMPONENTS="assoc,assoc_sh" /LOG' '{{DownloadUrl}}'
+  Install-ChocolateyPackage 'git.install' 'exe' '/VERYSILENT /NORESTART /NOCANCEL /SP- /NOICONS  /COMPONENTS="assoc,assoc_sh" /LOG' '{{DownloadUrl}}'
 
   #------- ADDITIONAL SETUP -------#
   $is64bit = (Get-WmiObject Win32_Processor).AddressWidth -eq 64


### PR DESCRIPTION
There is not need to specify these as this is Inno Setup's default
behavior anyway [1] [2]. Moreover, upcoming Git for Windows releases will
disable Inno Setup's built-in RestartManager in favor of a custom one that
is able to detect locking processes also prior to Windows Vista.

[1] http://www.jrsoftware.org/ishelp/index.php?topic=setup_closeapplications
[2] http://www.jrsoftware.org/ishelp/index.php?topic=setup_restartapplications
