### PR TITLE
Upgrade to TypeScript 1.0.1

### DIFF
--- a/manual/typescript.vs/tools/chocolateyInstall.ps1
+++ b/manual/typescript.vs/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = "typescript.vs"
 $installerType = "exe"
 $silentArgs= "/quiet"
-$url = "http://download.microsoft.com/download/2/F/F/2FFA1FBA-97CA-4FFB-8ED7-A4AE06398948/TypeScriptSetup.0.9.5.exe"
+$url = "http://visualstudiogallery.msdn.microsoft.com/ac357f1e-9847-46ac-a4cf-520325beaec1/file/132578/1/TypeScript%20for%20Microsoft%20Visual%20Studio%202012%201.0.1.exe"
 
 Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" -validExitCodes @(0)

--- a/manual/typescript.vs/typescript.vs.nuspec
+++ b/manual/typescript.vs/typescript.vs.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>typescript.vs</id>
-    <title>TypeScript.vs (Visual Studio 2012 and 2013)</title>
-    <version>0.9.5.0</version>
+    <title>TypeScript.vs (Visual Studio 2012)</title>
+    <version>1.0.1</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>
-    <summary>TypeScript for Visual Studio 2012 and 2013 - TypeScript editor and compiler for Visual Studio 2012 and 2013</summary>
+    <summary>TypeScript for Visual Studio 2012 - TypeScript editor and compiler for Visual Studio 2012</summary>
     <description>TypeScript is a language for application-scale JavaScript. TypeScript adds optional types, classes, and modules to JavaScript. TypeScript supports tools for large-scale JavaScript applications for any browser, for any host, on any OS. TypeScript compiles to clean, readable, standards-based JavaScript. Try it out at http://www.typescriptlang.org/playground.
 
-TypeScript for Visual Studio 2012 and 2013 provides a TypeScript editor and compiler for Visual Studio 2012/2013.</description>
+TypeScript for Visual Studio 2012 provides a TypeScript editor and compiler for Visual Studio 2012.</description>
     <projectUrl>http://www.typescriptlang.org/</projectUrl>
     <tags>typescript visualstudio vs2012 javascript admin</tags>
     <copyright></copyright>


### PR DESCRIPTION
This changes updates the download URL to the TypeScript 1.0.1 package, and also renames the package to include only Visual Studio 2012 in the name and description (TypeScript is now bundled with update 2013.2 instead of as a separate package).

I had sent you an email pointing you to a pull request I made in somebody else's repository. D'oh, sorry about that.
