### PR TITLE
jetty: fix move file command which starts too early. Fix output to console

### DIFF
--- a/automatic/jetty/tools/chocolateyInstall.ps1
+++ b/automatic/jetty/tools/chocolateyInstall.ps1
@@ -5,20 +5,14 @@ $fileName = $matches[1]
 $validExitCodes = @(0)
 $installDir = Join-Path $(Get-BinRoot) $packageName
 $installSubDir = Join-Path $installDir $fileName
-
-echo ("Package name: " + $packageName)
-echo ("Download URL: " + $downloadUrl)
-echo ("Install folder: " + $fileName)
-echo ("Folder name: " + $fileName)
-
 #Install
 Install-ChocolateyZipPackage "$packageName" "$downloadUrl" "$installDir"
+Sleep 5 # Wait for unzip to finish...hoping 5 seconds is enough. Todo: FIX BETTER SOLUTION
 
-# Move from subdir (e.g. jetty-v43253.543.45) in zip file to install root (jetty)
-mv (Join-Path $installSubDir "*") $installDir
+# Move from subdir (e.g. jetty-v43253.543.45) in zip file to install root (jetty). This to support uninstall
+mv -Force (Join-Path $installSubDir "*") $installDir
 rd $installSubDir
 
 # Report completed
 write-host ($packageName + " installed to ") -NoNewLine
 write-host -foregroundcolor Yellow  $installDir
-


### PR DESCRIPTION
If you have a better fix than the "sleep 5" for the script to wait for Install-ChocolateyZipPackage, please let me know