### PR TITLE
Updated Adobe Reader DC package

### DIFF
--- a/automatic/adobereader/adobereader.nuspec
+++ b/automatic/adobereader/adobereader.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>adobereader</id>
-    <version>15.007.20033.0</version>
+    <version>15.007.20033</version>
     <title>Adobe Reader</title>
     <authors>Adobe</authors>
     <licenseUrl>http://www.adobe.com/products/eulas/pdfs/Reader10_combined-20100625_1419.pdf</licenseUrl>

--- a/automatic/adobereader/adobereader.nuspec
+++ b/automatic/adobereader/adobereader.nuspec
@@ -1,25 +1,24 @@
-<?xml version="1.0" encoding="utf-8"?>
-<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>adobereader</id>
+    <version>15.007.20033.0</version>
     <title>Adobe Reader</title>
-    <version>{{PackageVersion}}</version>
     <authors>Adobe</authors>
-    <owners>Rob Reynolds</owners>
-    <summary>Adobe Reader – View and interact with PDF files</summary>
-    <description>
-Adobe Reader is the global standard for reliably viewing, printing, and commenting on PDF documents. It’s the only PDF file viewer that can open and interact with all types of PDF content, including forms and multimedia.
-
-Now includes support for installing English, Spanish, German, French or Japanese based on the LCID.
-    </description>
-    <projectUrl>http://www.adobe.com/products/reader.html</projectUrl>
-    <tags>adobereader pdf reader admin</tags>
     <licenseUrl>http://www.adobe.com/products/eulas/pdfs/Reader10_combined-20100625_1419.pdf</licenseUrl>
+    <projectUrl>http://www.adobe.com/products/reader.html</projectUrl>
+    <iconUrl>http://cdn.rawgit.com/ferventcoder/chocolatey-packages/bd3902ea9e357d5d1b3ece2977f02e5ef60ca84a/icons/adobereader.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/93b85c491c11089312f5735ffb199379b07fca46/icons/adobereader.png</iconUrl>
+    <description>
+Adobe Reader is the global standard for reliably viewing, printing, and commenting on PDF documents. It's the only PDF file viewer that can open and interact with all types of PDF content, including forms and multimedia.
+
+Now includes automatic language support based on the LCID.
+    </description>
+    <tags>adobe reader dc</tags>
+    <releaseNotes></releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />
   </files>
 </package>
-<!-- character encoding: “UTF-8” -->
+<!-- “UTF-8” test -->

--- a/automatic/adobereader/tools/chocolateyInstall.ps1
+++ b/automatic/adobereader/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ $arguments = @{}
 
   # Default value
   $lcid = $null
-
+  $RegValue = $null
 
   # Now parse the packageParameters using good old regular expression
   if ($packageParameters) {
@@ -40,19 +40,13 @@ $arguments = @{}
   }
 
   $scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-  Import-Module (Join-Path $scriptDir 'checkinstall.ps1')
+  Import-Module (Join-Path $scriptDir 'common.ps1')
   #If no Language ID passed through, use the one from Windows
   #LCID table can be found at http://msdn.microsoft.com/es-es/goglobal/bb964664.aspx to manually pass through the desired language. 
    if (!$lcid){ 
     $lcid = (Get-Culture).LCID
     echo "LCID set to $lcid"  
    }
-
-  
-  # Find download URLs at http://www.adobe.com/support/downloads/product.jsp?platform=windows&product=10
-  
-  $url = 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
-  $version = "15.007.20033"
 
 
   $packageName = 'adobereader'
@@ -65,22 +59,12 @@ $arguments = @{}
 
   #Check for current version installed
 
-  #Check for OS bitness
-if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match "64-bit"){
-$SoftwareKey = "HKLM:\Software\WOW6432Node" 
-} else {
-$SoftwareKey = "HKLM:\Software" 
-}
-#This is the current Adobe Reader key. Would like to find a way to automate this part.
-$RegKey = "$SoftwareKey\Microsoft\Windows\CurrentVersion\Uninstall\{AC76BA86-7AD7-FFFF-7B44-AC0F074E4100}"
-if (Test-Path "$RegKey") { 
-echo "Key Detected. Checking version..."
-     $RegValue = Get-ItemPropertyValue -Path $RegKey -Name DisplayVersion
-    echo "Version $RegValue detected, installer is $version"
-}
 
-
-
+    if ($currentinstall.DisplayVersion){
+    $RegValue = $currentinstall.DisplayVersion 
+    echo "Installed product detected. Version detected is $RegValue "
+    
+    }
 
   if ($RegValue -eq $version){
    echo "$version detected already installed. Skipping download and install."
@@ -89,6 +73,5 @@ echo "Key Detected. Checking version..."
   }
 
 } catch {
-  #Write-ChocolateyFailure $packageName $($_.Exception.Message)
-  throw
+    throw $_.Exception
 }

--- a/automatic/adobereader/tools/chocolateyInstall.ps1
+++ b/automatic/adobereader/tools/chocolateyInstall.ps1
@@ -1,90 +1,94 @@
-﻿$packageName = 'adobereader'
-$installerType = 'EXE'
-#Command Line Switches for the Bootstrap Web Installer: https://forums.adobe.com/message/3291894#3291894
-$silentArgs = '/sAll /msi /norestart /quiet ALLUSERS=1 EULA_ACCEPT=YES'
-$validExitCodes = @(0,3010) #3010: reboot required
-#$url = 'http://ardownload.adobe.com/pub/adobe/reader/win/{mainversion}.x/{version}/en_US/AdbeRdr{version:replace:.:}_en_US.exe'
-$url = '{{DownloadUrl}}'
+﻿try {
 
-Write-Debug "Detecting Locale..."
-# LCID table: #http://msdn.microsoft.com/goglobal/bb964664.aspx
-$mapping = @{
-  1033="en_US"; # 1033 = English - United States
-  2057="en_US"; # 2057 = English - United Kingdom
-  3081="en_US"; # 3081 = English - Australia
-  10249="en_US"; # 10249 = English - Belize
-  4105="en_US"; # 4105 = English - Canada
-  9225="en_US"; # 9225 = English - Caribbean
-  15369="en_US"; # 15369 = English - Hong Kong SAR
-  16393="en_US"; # 16393 = English - India
-  14345="en_US"; # 14345 = English - Indonesia
-  6153="en_US"; # 6153 = English - Ireland
-  8201="en_US"; # 8201 = English - Jamaica
-  17417="en_US"; # 17417 = English - Malaysia
-  5129="en_US"; # 5129 = English - New Zealand
-  13321="en_US"; # 13321 = English - Philippines
-  18441="en_US"; # 18441 = English - Singapore
-  7177="en_US"; # 7177 = English - South Africa
-  11273="en_US"; # 11273 = English - Trinidad
-  12297="en_US"; # 12297 = English - Zimbabwe
-  1036="fr_FR"; # 1036 = French - France
-  2060="fr_FR"; # 2060 = French - Belgium
-  11276="fr_FR"; # 11276 = French - Cameroon
-  3084="fr_FR"; # 3084 = French - Canada
-  9228="fr_FR"; # 9228 = French - Democratic Rep. of Congo
-  12300="fr_FR"; # 12300 = French - Cote d'Ivoire
-  15372="fr_FR"; # 15372 = French - Haiti
-  5132="fr_FR"; # 5132 = French - Luxembourg
-  13324="fr_FR"; # 13324 = French - Mali
-  6156="fr_FR"; # 6156 = French - Monaco
-  14348="fr_FR"; # 14348 = French - Morocco
-  58380="fr_FR"; # 58380 = French - North Africa
-  8204="fr_FR"; # 8204 = French - Reunion
-  10252="fr_FR"; # 10252 = French - Senegal
-  4108="fr_FR"; # 4108 = French - Switzerland
-  7180="fr_FR"; # 7180 = French - West Indies
-  1122="fr_FR"; # 1122 = Frisian - Netherlands
-  1127="fr_FR"; # 1127 = Fulfulde - Nigeria
-  1071="fr_FR"; # 1071 = FYRO Macedonian
-  1110="fr_FR"; # 1110 = Galician
-  1079="fr_FR"; # 1079 = Georgian
-  1031="de_DE"; # 1031 = German - Germany
-  3079="de_DE"; # 3079 = German - Austria
-  5127="de_DE"; # 5127 = German - Liechtenstein
-  4103="de_DE"; # 4103 = German - Luxembourg
-  2055="de_DE"; # 2055 = German - Switzerland
-  1041="ja_JP"; # 1041 = Japanese
-  3082="es_ES"; # 3082 = Spanish - Spain (Modern Sort)
-  1034="es_ES"; # 1034 = Spanish - Spain (Traditional Sort)
-  11274="es_ES"; # 11274 = Spanish - Argentina
-  16394="es_ES"; # 16394 = Spanish - Bolivia
-  13322="es_ES"; # 13322 = Spanish - Chile
-  9226="es_ES"; # 9226 = Spanish - Colombia
-  5130="es_ES"; # 5130 = Spanish - Costa Rica
-  7178="es_ES"; # 7178 = Spanish - Dominican Republic
-  12298="es_ES"; # 12298 = Spanish - Ecuador
-  17418="es_ES"; # 17418 = Spanish - El Salvador
-  4106="es_ES"; # 4106 = Spanish - Guatemala
-  18442="es_ES"; # 18442 = Spanish - Honduras
-  22538="es_ES"; # 22538 = Spanish - Latin America
-  2058="es_ES"; # 2058 = Spanish - Mexico
-  19466="es_ES"; # 19466 = Spanish - Nicaragua
-  6154="es_ES"; # 6154 = Spanish - Panama
-  15370="es_ES"; # 15370 = Spanish - Paraguay
-  10250="es_ES"; # 10250 = Spanish - Peru
-  20490="es_ES"; # 20490 = Spanish - Puerto Rico
-  21514="es_ES"; # 21514 = Spanish - United States
-  14346="es_ES"; # 14346 = Spanish - Uruguay
-  8202="es_ES"; # 8202 = Spanish - Venezuela
-}
-$LCID = (Get-Culture).LCID
-if ($mapping.ContainsKey($LCID)) {
-  $locale = $mapping.Get_Item($LCID);
-  Write-Host "Switching to $locale"
-  $url = $url -replace 'en_US', "$locale"
+$arguments = @{}
+
+  # Now we can use the $env:chocolateyPackageParameters inside the Chocolatey package
+  $packageParameters = $env:chocolateyPackageParameters
+
+  # Default value
+  $lcid = $null
+
+
+  # Now parse the packageParameters using good old regular expression
+  if ($packageParameters) {
+      $match_pattern = "\/(?<option>([a-zA-Z0-9]+)):(?<value>([`"'])?([a-zA-Z0-9- \(\)\s_\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"
+      $option_name = 'option'
+      $value_name = 'value'
+
+      if ($packageParameters -match $match_pattern ){
+          $results = $packageParameters | Select-String $match_pattern -AllMatches
+          $results.matches | % {
+            $arguments.Add(
+                $_.Groups[$option_name].Value.Trim(),
+                $_.Groups[$value_name].Value.Trim())
+        }
+      }
+      else
+      {
+          Throw "Package Parameters were found but were invalid (REGEX Failure)"
+      }
+
+      if ($arguments.ContainsKey("lcid")) {
+          Write-Host "lcid Argument Found"
+          $lcid = $arguments["lcid"]
+          echo "LCID set to $lcid"          
+      } 
+
+
+  } else {
+      Write-Debug "No Package Parameters Passed in"
+  }
+
+  $scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
+  Import-Module (Join-Path $scriptDir 'checkinstall.ps1')
+  #If no Language ID passed through, use the one from Windows
+  #LCID table can be found at http://msdn.microsoft.com/es-es/goglobal/bb964664.aspx to manually pass through the desired language. 
+   if (!$lcid){ 
+    $lcid = (Get-Culture).LCID
+    echo "LCID set to $lcid"  
+   }
+
+  
+  # Find download URLs at http://www.adobe.com/support/downloads/product.jsp?platform=windows&product=10
+  
+  $url = 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
+  $version = "15.007.20033"
+
+
+  $packageName = 'adobereader'
+  $installerType = 'exe'
+  $installArgs = "/sALL /rs /sl $lcid"
+  
+ #Kill the Adobe Updater AdobeARM.exe
+  
+  Stop-Process -processname AdobeARM -ErrorAction SilentlyContinue
+
+  #Check for current version installed
+
+  #Check for OS bitness
+if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match "64-bit"){
+$SoftwareKey = "HKLM:\Software\WOW6432Node" 
 } else {
-  Write-Debug "Leaving the url to the default English version."
-  $url = $url
+$SoftwareKey = "HKLM:\Software" 
+}
+#This is the current Adobe Reader key. Would like to find a way to automate this part.
+$RegKey = "$SoftwareKey\Microsoft\Windows\CurrentVersion\Uninstall\{AC76BA86-7AD7-FFFF-7B44-AC0F074E4100}"
+if (Test-Path "$RegKey") { 
+echo "Key Detected. Checking version..."
+     $RegValue = Get-ItemPropertyValue -Path $RegKey -Name DisplayVersion
+    echo "Version $RegValue detected, installer is $version"
 }
 
-Install-ChocolateyPackage "$packageName" "$installerType" "$silentArgs" "$url" -validExitCodes $validExitCodes
+
+
+
+  if ($RegValue -eq $version){
+   echo "$version detected already installed. Skipping download and install."
+  } else {
+    Install-ChocolateyPackage $packageName $installerType $installArgs $url -validExitCodes @(0,3010)     
+  }
+
+} catch {
+  #Write-ChocolateyFailure $packageName $($_.Exception.Message)
+  throw
+}

--- a/automatic/adobereader/tools/chocolateyUninstall.ps1
+++ b/automatic/adobereader/tools/chocolateyUninstall.ps1
@@ -1,24 +1,20 @@
 ﻿Write-Debug ("Starting " + $MyInvocation.MyCommand.Definition)
-
-[string]$packageName="Adobe Reader"
-
-<#
-Exit Codes:
-    0: installed successfully.
-    1605: not installed.
-    3010: A reboot is required to finish the install.
-#>
-
-#Kill Processes
-echo "Killing Processes..."
-if (Stop-Process -processname AdobeARM -PassThru -ErrorAction SilentlyContinue){
-echo "Killed updater..."
+$scriptDir = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
+Import-Module (Join-Path $scriptDir 'common.ps1')
+$fileType = 'msi';
+$silentArgs = '/qr /norestart'
+$validExitCodes = @(0,1605,3010)
+echo "Uninstalling version "$currentinstall.DisplayVersion 
+try {
+	
+	$file = $currentinstall.LocalPackage
+	
+    
+	$msiArgs = "/x $file $silentArgs";
+	Start-ChocolateyProcessAsAdmin "$msiArgs" 'msiexec' -validExitCodes $validExitCodes
+	
 }
-if (Stop-Process -processname AcroRd32 -PassThru -ErrorAction SilentlyContinue){
-echo "Killed Reader..."
-}
-echo "Begining uninstall..."
-Start-ChocolateyProcessAsAdmin "/qn /norestart /X{AC76BA86-7AD7-FFFF-7B44-AC0F074E4100}" -exeToRun "msiexec.exe" -validExitCodes @(0,1605,3010) 
-echo "Uninstall Complete!"
+catch {
 
-Write-Warning "$packageName may require a reboot to complete the uninstallation."
+	throw $_.Exception
+}

--- a/automatic/adobereader/tools/chocolateyUninstall.ps1
+++ b/automatic/adobereader/tools/chocolateyUninstall.ps1
@@ -1,0 +1,24 @@
+﻿Write-Debug ("Starting " + $MyInvocation.MyCommand.Definition)
+
+[string]$packageName="Adobe Reader"
+
+<#
+Exit Codes:
+    0: installed successfully.
+    1605: not installed.
+    3010: A reboot is required to finish the install.
+#>
+
+#Kill Processes
+echo "Killing Processes..."
+if (Stop-Process -processname AdobeARM -PassThru -ErrorAction SilentlyContinue){
+echo "Killed updater..."
+}
+if (Stop-Process -processname AcroRd32 -PassThru -ErrorAction SilentlyContinue){
+echo "Killed Reader..."
+}
+echo "Begining uninstall..."
+Start-ChocolateyProcessAsAdmin "/qn /norestart /X{AC76BA86-7AD7-FFFF-7B44-AC0F074E4100}" -exeToRun "msiexec.exe" -validExitCodes @(0,1605,3010) 
+echo "Uninstall Complete!"
+
+Write-Warning "$packageName may require a reboot to complete the uninstallation."

--- a/automatic/adobereader/tools/common.ps1
+++ b/automatic/adobereader/tools/common.ps1
@@ -1,0 +1,16 @@
+﻿  
+  # Find download URLs at http://www.adobe.com/support/downloads/product.jsp?platform=windows&product=10
+  
+  $url = 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
+  $version = "15.007.20033"
+
+  try {
+  $packageGuid = Get-ChildItem HKLM:\SOFTWARE\Classes\Installer\Products -ErrorAction SilentlyContinue |
+    	Get-ItemProperty -Name 'ProductName' -ErrorAction SilentlyContinue |
+    	? { $_.ProductName -like "Adobe" + "*" + "Reader" + "*"} |
+    	Select -ExpandProperty PSChildName -First 1 -ErrorAction SilentlyContinue
+	    write-host "Detected GUID: $packageGuid" 
+        $currentinstall = Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Products\$packageGuid\InstallProperties -ErrorAction SilentlyContinue
+  } catch {
+  echo "Could not detect GUID"
+  }


### PR DESCRIPTION
Added uninstall script, check for current version already installed, and
support for passing through LCID. (Although installer seems to use the
windows LCID as default anyways)