### PR TITLE
Notepad++ site is now https-only

### DIFF
--- a/automatic/notepadplusplus.commandline/notepadplusplus.commandline.ketarin.xml
+++ b/automatic/notepadplusplus.commandline/notepadplusplus.commandline.ketarin.xml
@@ -26,7 +26,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://notepad-plus-plus.org/</Url>
+            <Url>https://notepad-plus-plus.org/</Url>
             <StartText>&lt;p id="download"&gt;&lt;a href="download/v</StartText>
             <EndText>.html"&gt;Download&lt;/a&gt;</EndText>
             <Name>version</Name>
@@ -41,8 +41,8 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>http://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.bin\.zip</Regex>
-            <Url>http://notepad-plus-plus.org/download/v{version}.html</Url>
+            <Regex>https://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.bin\.zip</Regex>
+            <Url>https://notepad-plus-plus.org/download/v{version}.html</Url>
             <Name>folder</Name>
           </UrlVariable>
         </value>
@@ -60,7 +60,7 @@
     <FileHippoId>notepad</FileHippoId>
     <LastUpdated>2015-05-01T03:04:58.097644+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://notepad-plus-plus.org/repository/{folder}/{version}/npp.{version}.bin.zip</FixedDownloadUrl>
+    <FixedDownloadUrl>https://notepad-plus-plus.org/repository/{folder}/{version}/npp.{version}.bin.zip</FixedDownloadUrl>
     <Name>notepadplusplus.commandline</Name>
   </ApplicationJob>
 </Jobs>

--- a/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
+++ b/automatic/notepadplusplus.commandline/notepadplusplus.commandline.nuspec
@@ -17,7 +17,7 @@ You're encouraged to translate Notepad++ into your native tongue if there's not 
 
 I hope you enjoy Notepad++ as much as I enjoy coding it.
 </description>
-    <projectUrl>http://notepad-plus-plus.org/</projectUrl>
+    <projectUrl>https://notepad-plus-plus.org/</projectUrl>
     <tags>notepad notepadplusplus notepad-plus-plus</tags>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/notepadplusplus.png</iconUrl>
   </metadata>

--- a/automatic/notepadplusplus.install/notepadplusplus.install.ketarin.xml
+++ b/automatic/notepadplusplus.install/notepadplusplus.install.ketarin.xml
@@ -26,7 +26,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>http://notepad-plus-plus.org/</Url>
+            <Url>https://notepad-plus-plus.org/</Url>
             <StartText>&lt;p id="download"&gt;&lt;a href="download/v</StartText>
             <EndText>.html"&gt;Download&lt;/a&gt;</EndText>
             <Name>version</Name>
@@ -41,8 +41,8 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>http://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.Installer.exe</Regex>
-            <Url>http://notepad-plus-plus.org/download/v{version}.html</Url>
+            <Regex>https://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.Installer.exe</Regex>
+            <Url>https://notepad-plus-plus.org/download/v{version}.html</Url>
             <Name>folder</Name>
           </UrlVariable>
         </value>
@@ -60,7 +60,7 @@
     <FileHippoId>notepad</FileHippoId>
     <LastUpdated>2015-05-01T03:05:36.9121386+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://notepad-plus-plus.org/repository/{folder}/{version}/npp.{version}.Installer.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>https://notepad-plus-plus.org/repository/{folder}/{version}/npp.{version}.Installer.exe</FixedDownloadUrl>
     <Name>notepadplusplus.install</Name>
   </ApplicationJob>
 </Jobs>

--- a/automatic/notepadplusplus.install/notepadplusplus.install.nuspec
+++ b/automatic/notepadplusplus.install/notepadplusplus.install.nuspec
@@ -17,7 +17,7 @@ You're encouraged to translate Notepad++ into your native tongue if there's not 
 
 I hope you enjoy Notepad++ as much as I enjoy coding it.
 </description>
-    <projectUrl>http://notepad-plus-plus.org/</projectUrl>
+    <projectUrl>https://notepad-plus-plus.org/</projectUrl>
     <tags>notepad notepadplusplus notepad-plus-plus chocolatey admin</tags>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/notepadplusplus.png</iconUrl>
   </metadata>

--- a/automatic/notepadplusplus/notepadplusplus.nuspec
+++ b/automatic/notepadplusplus/notepadplusplus.nuspec
@@ -17,7 +17,7 @@ You're encouraged to translate Notepad++ into your native tongue if there's not 
 
 I hope you enjoy Notepad++ as much as I enjoy coding it.
 </description>
-    <projectUrl>http://notepad-plus-plus.org/</projectUrl>
+    <projectUrl>https://notepad-plus-plus.org/</projectUrl>
     <tags>notepad notepadplusplus notepad-plus-plus admin</tags>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/notepadplusplus.png</iconUrl>
     <dependencies>


### PR DESCRIPTION
Updating urls for notepad++ to access the resources via HTTPS.