### PR TITLE
Change the download folder variable regex to match new HTML

### DIFF
--- a/automatic/notepadplusplus.commandline/notepadplusplus.commandline.ketarin.xml
+++ b/automatic/notepadplusplus.commandline/notepadplusplus.commandline.ketarin.xml
@@ -41,7 +41,7 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>https://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.bin\.zip</Regex>
+            <Regex>/repository/([^\n\r]+?)/{version}/npp\.{version}\.bin\.zip</Regex>
             <Url>https://notepad-plus-plus.org/download/v{version}.html</Url>
             <Name>folder</Name>
           </UrlVariable>

--- a/automatic/notepadplusplus.install/notepadplusplus.install.ketarin.xml
+++ b/automatic/notepadplusplus.install/notepadplusplus.install.ketarin.xml
@@ -41,7 +41,7 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>https://notepad-plus-plus\.org/repository/([^\n\r]+?)/{version}/npp\.{version}\.Installer.exe</Regex>
+            <Regex>/repository/([^\n\r]+?)/{version}/npp\.{version}\.Installer.exe</Regex>
             <Url>https://notepad-plus-plus.org/download/v{version}.html</Url>
             <Name>folder</Name>
           </UrlVariable>


### PR DESCRIPTION
The download page no longer contains the domain in the url - just the absolute link. Ketarin is now showing that there's an update available with this file.

I've modified the Ketarin files but, as before, I haven't exported my local copy of the Ketarin-produced file (I assume that your server does that?).

Thanks, Dan