### PR TITLE
mono went from using exe to msi

### DIFF
--- a/automatic/mono/mono.ketarin.xml
+++ b/automatic/mono/mono.ketarin.xml
@@ -127,7 +127,7 @@
           <UrlVariable>
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>RegularExpression</VariableType>
-            <Regex>(?&lt;=http://download.mono-project.com/archive/)[\d\.]+/windows-installer/.+?\.exe</Regex>
+            <Regex>(?&lt;=http://download.mono-project.com/archive/)[\d\.]+/windows-installer/.+?\.msi</Regex>
             <Url>http://www.mono-project.com/download/#download-win</Url>
             <Name>urlPart</Name>
           </UrlVariable>

--- a/automatic/mono/tools/chocolateyInstall.ps1
+++ b/automatic/mono/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyPackage 'mono' 'exe' '/SILENT' '{{DownloadUrl}}'
+﻿Install-ChocolateyPackage 'mono' 'msi' '/SILENT' '{{DownloadUrl}}'


### PR DESCRIPTION
Just one caveat for this update.  I wasn't able to configure ketarin to update {{PackageVersion}} in my nuspec file, altough the regex to get the version looks ok.  It's prob a configuration issue on my end.  If that script has _ever_ worked on your end, it should work again with the 6 letters i changed in this pull.