### PR TITLE
7zip.commandline: fix typo in variable reference

### DIFF
--- a/automatic/7zip.commandline/tools/chocolateyInstall.ps1
+++ b/automatic/7zip.commandline/tools/chocolateyInstall.ps1
@@ -17,7 +17,7 @@ pushd "$toolsDir"
 popd
 
 $extrasUrl = "http://www.7-zip.org/a/7z$($versionMinusDots)-extra.7z"
-Install-ChocolateyZipPackage $packageId $extrasUrl $installDir
+Install-ChocolateyZipPackage $packageName $extrasUrl $installDir
 
 if (Get-ProcessorBits 32) {
   # generate ignore for x64\7za.exe


### PR DESCRIPTION
A mostly harmless bug - the package usually installs fine, but the downloaded zip is given a generic name ("Install.zip") and is placed in the root download cache directory, where it might collide with other packages exhibiting a similar bug.

````
 DEBUG: Running 'Install-ChocolateyZipPackage' for  with
 url:'http://www.7-zip.org/a/7z938-extra.7z', unzipLocation:
 'C:\ProgramData\chocolatey\lib\7zip.commandline\tools\7zip', url64bit: '',
 specificFolder: '', checksum: '', checksumType: '', checksum64: '',
 checksumType64: ''
 DEBUG: Running 'Get-ChocolateyWebFile' for  with
 url:'http://www.7-zip.org/a/7z938-extra.7z',
 fileFullPath:'C:\Users\Bla\AppData\Local\Temp\chocolatey\Install.zip',
````
