### PR TITLE
Using https for fetching SysInternals

### DIFF
--- a/automatic/sysinternals/tools/chocolateyInstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿
 $packageName = 'sysinternals'
-$url = 'http://download.sysinternals.com/files/SysinternalsSuite.zip'
+$url = 'https://download.sysinternals.com/files/SysinternalsSuite.zip'
 $installDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
 Install-ChocolateyZipPackage $packageName $url $installDir


### PR DESCRIPTION
Some internal corporate networks are blocking access to http://download.sysinternals.com/files/SysinternalsSuite.zip but https://download.sysinternals.com/files/SysinternalsSuite.zip works just fine.