### PR TITLE
Update ruby to the latest stable version

### DIFF
--- a/manual/ruby/ruby.nuspec
+++ b/manual/ruby/ruby.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>ruby</id>
-    <version>2.1.6</version>
+    <version>2.2.3</version>
     <title>Ruby</title>
     <authors>Yukihiro Matsumoto</authors>
     <owners>Rob Reynolds</owners>

--- a/manual/ruby/tools/chocolateyInstall.ps1
+++ b/manual/ruby/tools/chocolateyInstall.ps1
@@ -17,19 +17,25 @@
   # $url64 = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.0.0-p645-x64.exe?direct'
   # $checksum64 = '8f8f39d69a222b5472254969755ff5d36dc42585'
 
-  $rubyFolder = '21'
-  $url = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.6.exe?direct'
-  $checksum = '28aeded17ca34f685fb3fb862fb35ad9414edd05'
-  $url64 = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.6-x64.exe?direct'
-  $checksum64 = '07069b095c17f5b108e71951b4f16c410932a02d'
+  # $rubyFolder = '21'
+  # $url = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.6.exe?direct'
+  # $checksum = '28aeded17ca34f685fb3fb862fb35ad9414edd05'
+  # $url64 = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.6-x64.exe?direct'
+  # $checksum64 = '07069b095c17f5b108e71951b4f16c410932a02d'
+
+  $rubyFolder = '22'
+  $url = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.3.exe?direct'
+  $checksum = '2da40c04d7a3906b269e739b5627304f'
+  $url64 = 'http://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.3-x64.exe?direct'
+  $checksum64 = '9f123f08f1045ad1d49a99031f3e835e'
 
   $rubyPath = join-path $binRoot $('ruby' + "$rubyFolder")
   $silentArgs = "/verysilent /dir=`"$rubyPath`" /tasks=`"assocfiles,modpath`""
 
   # Install-ChocolateyPackage "$packageId" 'exe' "$silentArgs" "$url" -checksum $checksum
-  Install-ChocolateyPackage "$packageId" 'exe' "$silentArgs" "$url" "$url64"
-  #Checksum type sha1 has a bug fixed in 0.9.9.6 - https://github.com/chocolatey/choco/issues/253
-  #-checksum $checksum -checksumType 'sha1' -checksum64 $checksum64 -checksumType64 'sha1'
+  Install-ChocolateyPackage "$packageId" 'exe' "$silentArgs" "$url" "$url64" `
+    -checksum $checksum -checksumType 'md5' `
+    -checksum64 $checksum64 -checksumType64 'md5'
 
   $rubyBin = join-path $rubyPath 'bin'
   Write-Host "Adding `'$rubyBin`' to the local path"


### PR DESCRIPTION
Ruby 2.2.3 is now the latest stable version, so update to that.

I also turned checksum checking back on using the MD5 values from the [ruby installer release notes.](https://bintray.com/oneclick/rubyinstaller/rubyinstaller/2.2.3/view#release)

I wasn't sure if using a backtick in powershell scripts to split commands over multiple lines is ideal, but it seemed nicer than having one massive line.