### PR TITLE
Fixes problems running under SYSTEM account and kills git's instance of ssh-agent

### DIFF
--- a/automatic/_output/git.install/2.6.4.20151216/git.install.nuspec
+++ b/automatic/_output/git.install/2.6.4.20151216/git.install.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>git.install</id>
     <title>Git (Install)</title>
-    <version>{{PackageVersion}}</version>
+    <version>2.6.4.20151216</version>
     <authors>Johannes Schindelin, msysgit Committers</authors>
     <owners>Rob Reynolds, Darwin Sanoy</owners>
     <summary>Git (for Windows) – Fast Version Control</summary>

--- a/automatic/_output/git.install/2.6.4.20151216/tools/chocolateyInstall.ps1
+++ b/automatic/_output/git.install/2.6.4.20151216/tools/chocolateyInstall.ps1
@@ -1,0 +1,124 @@
+﻿$registryKeyName = 'Git_is1'
+$packageId = 'git.install'
+$fileType = 'exe'
+$fileArgs = $(
+  '/VERYSILENT /NORESTART /NOCANCEL /SP- ' +
+  '/NOICONS /COMPONENTS="icons,icons\quicklaunch,ext,ext\reg,ext\reg\shellhere,ext\reg\guihere,assoc,assoc_sh" /LOG'
+)
+$url = 'https://github.com/git-for-windows/git/releases/download/v2.6.4.windows.1/Git-2.6.4-32-bit.exe'
+$url64 = 'https://github.com/git-for-windows/git/releases/download/v2.6.4.windows.1/Git-2.6.4-64-bit.exe'
+
+$arguments = @{};
+# /GitOnlyOnPath /GitAndUnixToolsOnPath /NoAutoCrlf
+$packageParameters = $env:chocolateyPackageParameters;
+
+# Default the values
+$gitCmdOnly = $false
+$unixTools = $false
+$noAutoCrlf = $false # this does nothing unless true
+
+# Now parse the packageParameters using good old regular expression
+if ($packageParameters) {
+    $match_pattern = "\/(?<option>([a-zA-Z]+)):(?<value>([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"
+    #"
+    $option_name = 'option'
+    $value_name = 'value'
+
+    if ($packageParameters -match $match_pattern ){
+        $results = $packageParameters | Select-String $match_pattern -AllMatches
+        $results.matches | % {
+          $arguments.Add(
+              $_.Groups[$option_name].Value.Trim(),
+              $_.Groups[$value_name].Value.Trim())
+      }
+    }
+    else
+    {
+      throw "Package Parameters were found but were invalid (REGEX Failure)"
+    }
+
+    if ($arguments.ContainsKey("GitOnlyOnPath")) {
+        Write-Host "You want Git on the command line"
+        $gitCmdOnly = $true
+    }
+
+    if ($arguments.ContainsKey("GitAndUnixToolsOnPath")) {
+        Write-Host "You want Git and Unix Tools on the command line"
+        $unixTools = $true
+    }
+
+    if ($arguments.ContainsKey("NoAutoCrlf")) {
+        Write-Host "Ensuring core.autocrlf is false on first time install only"
+        Write-Host " This setting will not adjust an already existing .gitconfig setting."
+        $noAutoCrlf = $true
+    }
+} else {
+    Write-Debug "No Package Parameters Passed in";
+}
+
+$is64bit = (Get-ProcessorBits) -eq 64
+$installKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
+if ($is64bit -eq $true -and $env:chocolateyForceX86 -eq $true) {
+  $installKey = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
+}
+
+$userInstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$registryKeyName"
+if (Test-Path $userInstallKey) {
+  $installKey = $userInstallKey
+}
+
+if ( -not (Test-Path $installKey)) {
+  New-Item -Path $installKey | Out-Null
+}
+
+if ($gitCmdOnly) {
+  # update registry so installer picks it up automatically
+  New-ItemProperty $installKey -Name "Inno Setup CodeFile: Path Option" -Value "Cmd" -PropertyType "String" -Force | Out-Null
+}
+
+if ($unixTools) {
+  # update registry so installer picks it up automatically
+  New-ItemProperty $installKey -Name "Inno Setup CodeFile: Path Option" -Value "CmdTools" -PropertyType "String" -Force | Out-Null
+}
+
+if ($noAutoCrlf) {
+  # update registry so installer picks it up automatically
+  New-ItemProperty $installKey -Name "Inno Setup CodeFile: CRLF Option" -Value "CRLFCommitAsIs" -PropertyType "String" -Force | Out-Null
+}
+
+# Make our install work properly when running under SYSTEM account (Chef Cliet Service, Puppet Service, etc)
+# Add other items to this if block or use $IsRunningUnderSystemAccount to adjust existing logic that needs changing
+$IsRunningUnderSystemAccount = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).IsSystem
+If ($IsRunningUnderSystemAccount)
+{
+  #strip out quicklaunch parameter as it causes a hang under SYSTEM account
+  $fileArgs = $fileArgs.replace('icons\quicklaunch,','')
+  If ($fileArgs -inotlike "*/SUPPRESSMSGBOXES*")
+  {
+    $fileArgs = $fileArgs + ' /SUPPRESSMSGBOXES'
+  }
+}
+
+If ([bool](get-process ssh-agent -ErrorAction SilentlyContinue))
+{
+  Write-Output "Killing any git ssh-agent instances for install."
+  (get-process ssh-agent | where {$_.Path -ilike "*\git\usr\bin\*"}) | stop-process
+}
+
+Write-Output "The detailed git install log will be in either $env:windir\temp or $env:temp"
+
+Install-ChocolateyPackage $packageId $fileType $fileArgs $url $url64 -ValidExitCodes (0,3010)
+
+if (Test-Path $installKey) {
+  $keyNames = Get-ItemProperty -Path $installKey
+
+  if ($gitCmdOnly -eq $false -and $unixTools -eq $false) {
+    $installLocation = $keyNames.InstallLocation
+    if ($installLocation -ne '') {
+      $gitPath = Join-Path $installLocation 'cmd'
+      Install-ChocolateyPath $gitPath 'Machine'
+    }
+  }
+}
+
+Write-Warning "Git installed - You may need to close and reopen your shell for PATH changes to take effect."

--- a/automatic/_output/git.install/2.6.4.20151216/tools/chocolateyInstall.ps1
+++ b/automatic/_output/git.install/2.6.4.20151216/tools/chocolateyInstall.ps1
@@ -107,7 +107,7 @@ If ([bool](get-process ssh-agent -ErrorAction SilentlyContinue))
 
 Write-Output "The detailed git install log will be in either $env:windir\temp or $env:temp"
 
-Install-ChocolateyPackage $packageId $fileType $fileArgs $url $url64 -ValidExitCodes (0,3010)
+Install-ChocolateyPackage $packageId $fileType $fileArgs $url $url64
 
 if (Test-Path $installKey) {
   $keyNames = Get-ItemProperty -Path $installKey


### PR DESCRIPTION
If SYSTEM account is detected it strips 'icons\quicklaunch' from the feature list.  It also suppresses dialog boxes under system to generate an error rather than an eternal hang via dialog box.

This user folder does not exist for SYSTEM account profile and is not created on the fly by the installer (it assumes it is present as it would be for standard user profiles).  quicklaunch is technically depreciated.

Kills any instances of ssh-agent that are running from the git subfolder.

Displays to screen where to find log file in the case that an error is generated.  Should probably log this as well.

FYI - I hate it when choco packages don't [a] enable logging on the underlying installer, [b] tell where that log is because it is sometimes redirected by the fact of operating under choco - makes diagnosing problems unnecessarily hard - would be great to add logging *encouragement* to the choco new template.