### PR TITLE
Add dependency to .NET 4.6 in Paint.NET package

### DIFF
--- a/automatic/paint.net/paint.net.nuspec
+++ b/automatic/paint.net/paint.net.nuspec
@@ -13,6 +13,9 @@
     <licenseUrl>http://www.getpaint.net/license.html</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/paint.net.png</iconUrl>
+    <dependencies>
+      <dependency id="DotNet4.6" version="4.6.00081.20150925" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
Dependency is to the lowest (and only) non RC version of .NET 4.6