### PR TITLE
Add package parameter to install to custom directory

### DIFF
--- a/automatic/sysinternals/tools/chocolateyInstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyInstall.ps1
@@ -3,32 +3,46 @@ $packageName = 'sysinternals'
 $url = 'https://live.sysinternals.com/files/SysinternalsSuite.zip'
 $installDir = Split-Path -parent $MyInvocation.MyCommand.Definition
 
+# Default the values
+$defaultInstallDir = Split-Path -parent $MyInvocation.MyCommand.Definition
+$installDir = $defaultInstallDir
+
+# Now parse the packageParameters using good old regular expression
+if ($packageParameters -and $packageParameters.Length -gt 18) {
+  if ($packageParameters.ToLower().SubString(0,18) -eq '/installationpath:') {
+    Write-Host "You want to use a custom Installation Path"
+    Write-Warning "By using a custom path, chocolatey will not uninstall sysinternals"
+    $installDir = $packageParameters.ToLower().SubString(18,$packageParameters.Length - 18)
+  }
+}
+
 Install-ChocolateyZipPackage $packageName $url $installDir
 
-
-@(
-'AccessEnum',
-'ADExplorer',
-'AdInsight',
-'Autoruns',
-'Bginfo',
-'Cachset',
-'Dbgview',
-'Desktops',
-'disk2vhd',
-'DiskView',
-'LoadOrd',
-'pagedfrg',
-'portmon',
-'procexp',
-'Procmon',
-'RAMMap',
-'RootkitRevealer',
-'Tcpview',
-'vmmap',
-'ZoomIt'
-) | % {
-  New-Item "$installDir\$_.exe.gui" -Type file -Force | Out-Null
+if ($installDir -eq $defaultInstallDir) {
+  @(
+  'AccessEnum',
+  'ADExplorer',
+  'AdInsight',
+  'Autoruns',
+  'Bginfo',
+  'Cachset',
+  'Dbgview',
+  'Desktops',
+  'disk2vhd',
+  'DiskView',
+  'LoadOrd',
+  'pagedfrg',
+  'portmon',
+  'procexp',
+  'Procmon',
+  'RAMMap',
+  'RootkitRevealer',
+  'Tcpview',
+  'vmmap',
+  'ZoomIt'
+  ) | % {
+    New-Item "$installDir\$_.exe.gui" -Type file -Force | Out-Null
+  }
 }
 
 Write-Warning "Clean up older versions of this install, most likely at c:\sysinternals"


### PR DESCRIPTION
This commit adds a package parameter of `/installpath:` which will install the
sysinternal tools to a non-default path.  Note that chocolatey will not be able
to uninstall sysinternals but will still succeed.