### PR TITLE
git.commandline: only shim /cmd/git.exe and /git-bash.exe

### DIFF
--- a/automatic/git.commandline/tools/chocolateyInstall.ps1
+++ b/automatic/git.commandline/tools/chocolateyInstall.ps1
@@ -13,7 +13,7 @@ $deprecatedInstallDir = Join-Path $env:systemdrive 'git'
 $files = get-childitem $installDir -include *.exe -recurse
 
 foreach ($file in $files) {
-  if (!($file.Name.Contains("git.exe")) -and !($file.Name.Contains("ssh"))) {
+  if (!($file.FullName -match '\\cmd\\git.exe$|\\git-bash.exe$|ssh[^\\]$')) {
     #generate an ignore file
     New-Item "$file.ignore" -type file -force | Out-Null
   }


### PR DESCRIPTION
Fixes #85, adds `git-bash` shim. Also removes ssh conflict with `win32-openssh`.