### PR TITLE
Putty version - fix download url

### DIFF
--- a/automatic/_output/putty.install/0.63/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.install/0.63/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName = 'putty.install'
 $fileType = 'exe'
 $silentArgs = '/VERYSILENT'
-$url = 'http://the.earth.li/~sgtatham/putty/latest/x86/putty-0.63-installer.exe'
+$url = 'http://the.earth.li/~sgtatham/putty/0.63/x86/putty-0.63-installer.exe'
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url

--- a/automatic/_output/putty.install/0.64/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.install/0.64/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName = 'putty.install'
 $fileType = 'exe'
 $silentArgs = '/VERYSILENT'
-$url = 'http://the.earth.li/~sgtatham/putty/latest/x86/putty-0.64-installer.exe'
+$url = 'http://the.earth.li/~sgtatham/putty/0.64/x86/putty-0.64-installer.exe'
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url

--- a/automatic/_output/putty.install/0.65/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.install/0.65/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName = 'putty.install'
 $fileType = 'exe'
 $silentArgs = '/VERYSILENT'
-$url = 'http://the.earth.li/~sgtatham/putty/latest/x86/putty-0.65-installer.exe'
+$url = 'http://the.earth.li/~sgtatham/putty/0.65/x86/putty-0.65-installer.exe'
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url

--- a/automatic/_output/putty.install/0.66/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.install/0.66/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿$packageName = 'putty.install'
 $fileType = 'exe'
 $silentArgs = '/VERYSILENT'
-$url = 'http://the.earth.li/~sgtatham/putty/latest/x86/putty-0.66-installer.exe'
+$url = 'http://the.earth.li/~sgtatham/putty/0.66/x86/putty-0.66-installer.exe'
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url

--- a/automatic/_output/putty.portable/0.63/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.portable/0.63/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/latest/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/0.63/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/automatic/_output/putty.portable/0.64/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.portable/0.64/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/latest/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/0.64/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/automatic/_output/putty.portable/0.65/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.portable/0.65/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/latest/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/0.65/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/automatic/_output/putty.portable/0.66/tools/chocolateyInstall.ps1
+++ b/automatic/_output/putty.portable/0.66/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/latest/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+﻿Install-ChocolateyZipPackage 'putty' 'http://the.earth.li/~sgtatham/putty/0.66/x86/putty.zip'  "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/ketarin/putty.install.ketarin.xml
+++ b/ketarin/putty.install.ketarin.xml
@@ -130,7 +130,7 @@
     <FileHippoId />
     <LastUpdated>2013-08-07T22:22:28.8834069+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://the.earth.li/~sgtatham/putty/latest/x86/putty-{version}-installer.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>http://the.earth.li/~sgtatham/putty/{version}/x86/putty-{version}-installer.exe</FixedDownloadUrl>
     <Name>putty.install</Name>
   </ApplicationJob>
 </Jobs>

--- a/ketarin/putty.portable.ketarin.xml
+++ b/ketarin/putty.portable.ketarin.xml
@@ -132,7 +132,7 @@ REM /disablepush</ExecutePreCommand>
     <FileHippoId />
     <LastUpdated>2013-08-07T22:22:30.1121369+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://the.earth.li/~sgtatham/putty/latest/x86/putty.zip</FixedDownloadUrl>
+    <FixedDownloadUrl>http://the.earth.li/~sgtatham/putty/{version}/x86/putty.zip</FixedDownloadUrl>
     <Name>putty.portable</Name>
   </ApplicationJob>
 </Jobs>


### PR DESCRIPTION
Putty currently has a download url with the version number as part of the url. The current code always used "latest". Because of this it is not possible to install an older version of putty, and it is currently not possible to install the most recent chocolatey version (0.66).