### PR TITLE
Auto-Eula

### DIFF
--- a/automatic/sysinternals/tools/chocolateyInstall.ps1
+++ b/automatic/sysinternals/tools/chocolateyInstall.ps1
@@ -31,4 +31,9 @@ Install-ChocolateyZipPackage $packageName $url $installDir
   New-Item "$installDir\$_.exe.gui" -Type file -Force | Out-Null
 }
 
+New-Item "HKCU:\SOFTWARE\Sysinternals" -Force | Out-Null
+@("A","AccessChk","Active Directory Explorer","ADInsight","Autologon","AutoRuns","BGInfo","C","CacheSet","ClockRes","Coreinfo","Ctrl2cap","DbgView","Desktops","Disk2Vhd","Diskmon","DiskView","Du","EFSDump","FindLinks","Handle","Hex2Dec","Junction","LdmDump","ListDLLs","LoadOrder","Movefile","PageDefrag","PendMove","PipeList","Portmon","ProcDump","Process Explorer",  "Process Monitor","PsExec","psfile","PsGetSid","PsInfo","PsKill","PsList","PsLoggedon","PsLoglist","PsPasswd","PsService","PsShutdown","PsSuspend","RamMap","RegDelNull","Regjump","Regsize",  "RootkitRevealer","Share Enum","ShellRunas - Sysinternals: www.sysinternals.com","SigCheck","Streams","Strings","Sync","System Monitor","TCPView","VMMap","VolumeID","Whois","Winobj","ZoomIt") | % {
+  New-Item (Join-Path -Path 'HKCU:\SOFTWARE\Sysinternals' -ChildPath "$_") -Force | New-ItemProperty -Name "EulaAccepted" -Value 1 -Force | Out-Null
+  }
+
 Write-Warning "Clean up older versions of this install, most likely at c:\sysinternals"


### PR DESCRIPTION
Change: Auto-Accept eula for the utilities in the sysinternals suite

Reasoning:
Currently, user accepts eula during the install (with choco) and then has to later re-accept eula for the various utilities.  

This fix (adding EulaAccepted=1 to HKCU:\Sysinternals\<utility-name>) prevents this from occuring.