### PR TITLE
Update nodejs.install script

### DIFF
--- a/ketarin/nodejs.install.ketarin.xml
+++ b/ketarin/nodejs.install.ketarin.xml
@@ -26,7 +26,7 @@
             <RegexRightToLeft>false</RegexRightToLeft>
             <VariableType>StartEnd</VariableType>
             <Regex />
-            <Url>https://nodejs.org/en/download/stable/</Url>
+            <Url>https://nodejs.org/en/download/current/</Url>
             <StartText>data-version="v</StartText>
             <EndText>"&gt;</EndText>
             <TextualContent />


### PR DESCRIPTION
They've updated the nomenclature from "stable" to "current"

I don't know if this is related to the v6 package not being available yet (the URL that was there does redirect), but thought I'd update since I noticed.