### PR TITLE
Added windowsterminal opt to git

### DIFF
--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -21,6 +21,7 @@ The following package parameters can be set:
  * `/GitOnlyOnPath` - this puts gitinstall\cmd on path. This is also done by default if no package parameters are set.
  * `/GitAndUnixToolsOnPath` - this puts gitinstall\bin on path. This setting will override `/GitOnlyOnPath`.
  * `/NoAutoCrlf` - this setting only affects new installs, it will not override an existing `.gitconfig`. This will ensure 'Checkout as is, commit as is'
+ * `/WindowsTerminal` - this makes vim use the regular Windows terminal instead of MinTTY terminal
 
 These parameters can be passed to the installer with the use of `-params`.
 For example: `-params '"/GitAndUnixToolsOnPath /NoAutoCrlf"'`.

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -13,6 +13,7 @@ $arguments = @{};
 $packageParameters = $env:chocolateyPackageParameters;
 
 # Default the values
+$useWindowsTerminal = $false
 $gitCmdOnly = $false
 $unixTools = $false
 $noAutoCrlf = $false # this does nothing unless true
@@ -40,6 +41,11 @@ if ($packageParameters) {
     if ($arguments.ContainsKey("GitOnlyOnPath")) {
         Write-Host "You want Git on the command line"
         $gitCmdOnly = $true
+    }
+
+    if ($arguments.ContainsKey("WindowsTerminal")) {
+        Write-Host "You do not want to use MinTTY terminal"
+        $useWindowsTerminal = $true
     }
 
     if ($arguments.ContainsKey("GitAndUnixToolsOnPath")) {
@@ -74,6 +80,11 @@ if ( -not (Test-Path $installKey)) {
 if ($gitCmdOnly) {
   # update registry so installer picks it up automatically
   New-ItemProperty $installKey -Name "Inno Setup CodeFile: Path Option" -Value "Cmd" -PropertyType "String" -Force | Out-Null
+}
+
+if ($useWindowsTerminal) {
+  # update registry so installer picks it up automatically
+  New-ItemProperty $installKey -Name "Inno Setup CodeFile: Bash Terminal Option" -Value "ConHost" -PropertyType "String" -Force | Out-Null
 }
 
 if ($unixTools) {


### PR DESCRIPTION
Added option `WindowsTerminal` which lets you install git without the MinTTY terminal so it just uses the regular windows terminal. 

Closes #88
