### PR TITLE
fix mysql download urls

### DIFF
--- a/automatic/mysql/tools/chocolateyInstall.ps1
+++ b/automatic/mysql/tools/chocolateyInstall.ps1
@@ -3,8 +3,8 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $packageName = 'mysql'
 $packageType = 'msi'
 $silentArgs = '/passive'
-$url = 'https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-{{PackageVersion}}-win32.zip'
-$url64 = 'https://cdn.mysql.com/Downloads/MySQL-5.7/mysql-{{PackageVersion}}-winx64.zip'
+$url = 'https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-{{PackageVersion}}-win32.zip'
+$url64 = 'https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-{{PackageVersion}}-winx64.zip'
 
 $binRoot = Get-BinRoot
 $installDir = Join-Path $binRoot "$packageName"


### PR DESCRIPTION
because cdn.mysql.com url does not work for previous versions
for example:
https://cdn.mysql.com/downloads/mysql-5.7/mysql-5.7.13-win32.zip - 404 error
https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.13-win32.zip - 200 ok