### PR TITLE
Fix downloadlinks for Vagrant 1.7.x

### DIFF
--- a/automatic/_output/vagrant/1.7.3.20160919/tools/chocolateyinstall.ps1
+++ b/automatic/_output/vagrant/1.7.3.20160919/tools/chocolateyinstall.ps1
@@ -1,0 +1,12 @@
+﻿$packageName = 'vagrant'
+$url = 'https://releases.hashicorp.com/vagrant/1.7.3/vagrant_1.7.3.msi'
+
+$packageArgs = @{
+  packageName   = $packageName
+  fileType      = 'msi'
+  url           = $url
+  silentArgs    = "/qn /norestart"
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/automatic/_output/vagrant/1.7.3.20160919/tools/chocolateyuninstall.ps1
+++ b/automatic/_output/vagrant/1.7.3.20160919/tools/chocolateyuninstall.ps1
@@ -1,0 +1,20 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$packageName = 'vagrant'
+$packageSearch = 'Vagrant'
+$installerType = 'msi' 
+$silentArgs = "/qn /norestart"
+# https://msdn.microsoft.com/en-us/library/aa376931(v=vs.85).aspx
+$validExitCodes = @(0, 3010, 1605, 1614, 1641)
+
+Get-ItemProperty  -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' ) `
+                  -ErrorAction:SilentlyContinue `
+  | Where-Object   { $_.DisplayName -like "$packageSearch*" } `
+  | ForEach-Object { 
+      Uninstall-ChocolateyPackage -PackageName "$packageName" `
+                                  -FileType "$installerType" `
+                                  -SilentArgs "$($_.PSChildName) $silentArgs" `
+                                  -ValidExitCodes $validExitCodes 
+    }

--- a/automatic/_output/vagrant/1.7.3.20160919/vagrant.nuspec
+++ b/automatic/_output/vagrant/1.7.3.20160919/vagrant.nuspec
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>vagrant</id>
+    <title>Vagrant (Install)</title>
+    <version>1.7.3.20160919</version>
+    <authors>Mitchell Hashimoto, John Bender, HashiCorp</authors>
+    <owners>Rob Reynolds, Patrick Wyatt</owners>
+    <summary>Vagrant - Development environments made easy.</summary>
+    <description>
+Vagrant - Development environments made easy. Create and configure lightweight, reproducible, and portable development environments.
+
+#### About
+Vagrant is a tool for building complete development environments. With an easy-to-use workflow and focus on automation, Vagrant lowers development environment setup time, increases development/production parity, and makes the "works on my machine" excuse a relic of the past.
+
+Vagrant was started in January 2010 by [Mitchell Hashimoto](http://twitter.com/mitchellh). For almost three years, Vagrant was a side-project for Mitchell, a project that he worked on in his free hours after his full-time job. During this time, Vagrant grew to be trusted and used by a range of individuals to entire development teams in large companies.
+
+In November 2012, [HashiCorp](http://www.hashicorp.com/) was formed by Mitchell to back the development of Vagrant full-time. HashiCorp builds commercial additions and provides professional support and training for Vagrant.
+
+Vagrant remains and always will be a liberally licensed open source project. Each release of Vagrant is the work of hundreds of individuals' contributions to the [open source project](http://github.com/mitchellh/vagrant).
+
+**Please Note**: This is an automatically updated package. If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.</description>
+    <projectUrl>https://www.vagrantup.com</projectUrl>
+    <packageSourceUrl>https://github.com/ferventcoder/chocolatey-packages</packageSourceUrl>
+    <projectSourceUrl>https://github.com/mitchellh/vagrant</projectSourceUrl>
+    <docsUrl>https://docs.vagrantup.com/v2/</docsUrl>
+    <mailingListUrl>https://groups.google.com/forum/#!forum/vagrant-up</mailingListUrl>
+    <bugTrackerUrl>https://github.com/mitchellh/vagrant/issues</bugTrackerUrl>
+    <tags>vagrant admin sandbox virtual machine testing VM VirtualBox VMware</tags>
+    <copyright>Copyright 2015 HashiCorp</copyright>
+    <licenseUrl>https://github.com/mitchellh/vagrant/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/768abfcbe194f56e9bb3fed32ed61849886dbcf2/icons/vagrant.png</iconUrl>
+    <releaseNotes>[CHANGELOG](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md)</releaseNotes>
+    <!--<provides>vagrant</provides>-->
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/_output/vagrant/1.7.4.20160919/tools/chocolateyinstall.ps1
+++ b/automatic/_output/vagrant/1.7.4.20160919/tools/chocolateyinstall.ps1
@@ -1,0 +1,12 @@
+﻿$packageName = 'vagrant'
+$url = 'https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi'
+
+$packageArgs = @{
+  packageName   = $packageName
+  fileType      = 'msi'
+  url           = $url
+  silentArgs    = "/qn /norestart"
+  validExitCodes= @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/automatic/_output/vagrant/1.7.4.20160919/tools/chocolateyuninstall.ps1
+++ b/automatic/_output/vagrant/1.7.4.20160919/tools/chocolateyuninstall.ps1
@@ -1,0 +1,20 @@
+﻿$ErrorActionPreference = 'Stop';
+
+$packageName = 'vagrant'
+$packageSearch = 'Vagrant'
+$installerType = 'msi' 
+$silentArgs = "/qn /norestart"
+# https://msdn.microsoft.com/en-us/library/aa376931(v=vs.85).aspx
+$validExitCodes = @(0, 3010, 1605, 1614, 1641)
+
+Get-ItemProperty  -Path @( 'HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*',
+                          'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*' ) `
+                  -ErrorAction:SilentlyContinue `
+  | Where-Object   { $_.DisplayName -like "$packageSearch*" } `
+  | ForEach-Object { 
+      Uninstall-ChocolateyPackage -PackageName "$packageName" `
+                                  -FileType "$installerType" `
+                                  -SilentArgs "$($_.PSChildName) $silentArgs" `
+                                  -ValidExitCodes $validExitCodes 
+    }

--- a/automatic/_output/vagrant/1.7.4.20160919/vagrant.nuspec
+++ b/automatic/_output/vagrant/1.7.4.20160919/vagrant.nuspec
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>vagrant</id>
+    <title>Vagrant (Install)</title>
+    <version>1.7.4.20160919</version>
+    <authors>Mitchell Hashimoto, John Bender, HashiCorp</authors>
+    <owners>Rob Reynolds, Patrick Wyatt</owners>
+    <summary>Vagrant - Development environments made easy.</summary>
+    <description>
+Vagrant - Development environments made easy. Create and configure lightweight, reproducible, and portable development environments.
+
+#### About
+Vagrant is a tool for building complete development environments. With an easy-to-use workflow and focus on automation, Vagrant lowers development environment setup time, increases development/production parity, and makes the "works on my machine" excuse a relic of the past.
+
+Vagrant was started in January 2010 by [Mitchell Hashimoto](http://twitter.com/mitchellh). For almost three years, Vagrant was a side-project for Mitchell, a project that he worked on in his free hours after his full-time job. During this time, Vagrant grew to be trusted and used by a range of individuals to entire development teams in large companies.
+
+In November 2012, [HashiCorp](http://www.hashicorp.com/) was formed by Mitchell to back the development of Vagrant full-time. HashiCorp builds commercial additions and provides professional support and training for Vagrant.
+
+Vagrant remains and always will be a liberally licensed open source project. Each release of Vagrant is the work of hundreds of individuals' contributions to the [open source project](http://github.com/mitchellh/vagrant).
+
+**Please Note**: This is an automatically updated package. If you find it is out of date by more than a day or two, please contact the maintainer(s) and let them know the package is no longer updating correctly.</description>
+    <projectUrl>https://www.vagrantup.com</projectUrl>
+    <packageSourceUrl>https://github.com/ferventcoder/chocolatey-packages</packageSourceUrl>
+    <projectSourceUrl>https://github.com/mitchellh/vagrant</projectSourceUrl>
+    <docsUrl>https://docs.vagrantup.com/v2/</docsUrl>
+    <mailingListUrl>https://groups.google.com/forum/#!forum/vagrant-up</mailingListUrl>
+    <bugTrackerUrl>https://github.com/mitchellh/vagrant/issues</bugTrackerUrl>
+    <tags>vagrant admin sandbox virtual machine testing VM VirtualBox VMware</tags>
+    <copyright>Copyright 2015 HashiCorp</copyright>
+    <licenseUrl>https://github.com/mitchellh/vagrant/blob/master/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/768abfcbe194f56e9bb3fed32ed61849886dbcf2/icons/vagrant.png</iconUrl>
+    <releaseNotes>[CHANGELOG](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md)</releaseNotes>
+    <!--<provides>vagrant</provides>-->
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This PR fixes #178 by updating the download links for Vagrant to the https://releases.hashicorp.com/ URL's.

