### PR TITLE
Update functions.ps1

### DIFF
--- a/automatic/dropbox/tools/functions.ps1
+++ b/automatic/dropbox/tools/functions.ps1
@@ -1,5 +1,6 @@
 ﻿Function getDropboxRegProps() {
-  $uninstallRegistryPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
+  $uninstallRegistryPath = 'HKLM:\Software' + $bitness + '\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
+  $bitness = @{$true = "\WOW6432Node"; $false = ""}[ (Get-ProcessorBits) -eq 64 ]
 
   if (Test-Path $uninstallRegistryPath) {
     $props = @{

--- a/automatic/dropbox/tools/functions.ps1
+++ b/automatic/dropbox/tools/functions.ps1
@@ -1,13 +1,6 @@
 ﻿Function getDropboxRegProps() {
-  $bitness = @{$true = "\WOW6432Node"; $false = ""}[ (Get-ProcessorBits) -eq 64 ]
-  $uninstallRegistryPath = 'HKLM:\Software' + $bitness + '\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
-
-  if (Test-Path $uninstallRegistryPath) {
-    $props = @{
-      "DisplayVersion" = (Get-ItemProperty $uninstallRegistryPath).DisplayVersion
-      "UninstallString" = (Get-ItemProperty $uninstallRegistryPath).UninstallString
-    }
-  }
+ 
+  [array]$props = Get-UninstallRegistryKey -SoftwareName "Dropbox" # This will use Chocolatey Helper Get-UninstallRegistryKey to get all registry keys for Dropbox
 
   return $props
 }

--- a/automatic/dropbox/tools/functions.ps1
+++ b/automatic/dropbox/tools/functions.ps1
@@ -1,6 +1,6 @@
 ﻿Function getDropboxRegProps() {
-  $uninstallRegistryPath = 'HKLM:\Software' + $bitness + '\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
   $bitness = @{$true = "\WOW6432Node"; $false = ""}[ (Get-ProcessorBits) -eq 64 ]
+  $uninstallRegistryPath = 'HKLM:\Software' + $bitness + '\Microsoft\Windows\CurrentVersion\Uninstall\Dropbox'
 
   if (Test-Path $uninstallRegistryPath) {
     $props = @{


### PR DESCRIPTION
The Dropbox Uninstall Registry Keys are not stored under the HKCU Uninstall. They are stored under the HKLM Uninstall and the WOW6432Node on a 64bit system.

@ferventcoder I'm sure you would have fixed this in your free time 👍 
