### PR TITLE
(php) Fixes for php.ini and extensions not working out of the box

### DIFF
--- a/automatic/php/tools/chocolateyInstall.ps1
+++ b/automatic/php/tools/chocolateyInstall.ps1
@@ -36,4 +36,14 @@ $validExitCodes = @(0)
 $targetFolder = Join-Path $(Get-BinRoot) $packageName
 Install-ChocolateyZipPackage "$packageName" "$url" "$targetFolder" "$url64"
 Install-ChocolateyPath $targetFolder
+
+$phpIniPath = $targetFolder + '/php.ini'
+if (!(Test-Path $phpIniPath)) {
+  write-host 'Creating default php.ini'
+  Copy-Item $targetFolder/php.ini-production $phpIniPath
+
+  write-host 'Configuring PHP extensions directory'
+  (Get-Content $phpIniPath) -replace '; extension_dir = "ext"', 'extension_dir = "ext"' | Set-Content $phpIniPath
+}
+
 echo ("PHP installed in " + $targetFolder)


### PR DESCRIPTION
Fixes issue #145, creating a default php.ini and changing the extension_dir configuration

I'm not very experienced with Powershell or Chocolatey packaging. If there's anything you believe I should change in the code, just let me know.
