### PR TITLE
(7zip.install) https links

### DIFF
--- a/automatic/7zip.install/tools/chocolateyInstall.ps1
+++ b/automatic/7zip.install/tools/chocolateyInstall.ps1
@@ -10,8 +10,8 @@ Write-Warning "This installer is known to close the explorer process. This means
 
 $versionMinusDots = "{{PackageVersion}}".Replace(".","")
 $packageId = '7zip.install'
-$url = "http://www.7-zip.org/a/7z$($versionMinusDots).exe"
-$url64 = "http://www.7-zip.org/a/7z$($versionMinusDots)-x64.exe"
+$url = "https://sourceforge.net/projects/sevenzip/files/7-Zip/{{PackageVersion}}/7z${versionMinusDots}.exe/download"
+$url64 = "https://sourceforge.net/projects/sevenzip/files/7-Zip/{{PackageVersion}}/7z${versionMinusDots}-x64.exe/download"
 
 Install-ChocolateyPackage $packageId 'exe' '/S' $url $url64
 

--- a/ketarin/7zip.install.ketarin.xml
+++ b/ketarin/7zip.install.ketarin.xml
@@ -83,7 +83,7 @@ chocopkgup /p 7zip.commandline /v {version} /u {preupdate-url} /u64 {url64}</Exe
     <FileHippoId />
     <LastUpdated>2015-07-12T00:05:08.5170668-07:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://www.7-zip.org/a/7z{VersionNoDots}.exe</FixedDownloadUrl>
+    <FixedDownloadUrl>https://sourceforge.net/projects/sevenzip/files/7-Zip/{version}/7z{VersionNoDots}.exe/download</FixedDownloadUrl>
     <Name>7zip.install</Name>
   </ApplicationJob>
 </Jobs>


### PR DESCRIPTION
#198 Updated 7zip.install package to point to https sourceforge download links so that choco won't prevent installation due to lack of checksums.

I'm pretty sure that this should fix the issue, when I manually sub in the values so that I can pack a nupkg which installs successfully. Although I'm not hugely familiar with how the auto packaging works so I could be miles off the mark.