### PR TITLE
(adobereader) base package checksum

### DIFF
--- a/automatic/_output/adobereader/2015.007.20033/tools/chocolateyInstall.ps1
+++ b/automatic/_output/adobereader/2015.007.20033/tools/chocolateyInstall.ps1
@@ -4,5 +4,7 @@ $installerType = 'EXE'
 $silentArgs = '/sAll /msi /norestart /quiet ALLUSERS=1 EULA_ACCEPT=YES'
 $url = 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
 $validExitCodes = @(0, 3010)
+$checksumType = 'sha256'
+$checksum = 'dfc4b3c70b7ecaeb40414c9d6591d8952131a5fffa0c0f5964324af7154f8111'
 
-Install-ChocolateyPackage $packageName $installerType $silentArgs $url -validExitCodes $validExitCodes
+Install-ChocolateyPackage $packageName $installerType $silentArgs $url -validExitCodes $validExitCodes -Checksum $checksum -ChecksumType $checksumType


### PR DESCRIPTION
I know this is probably not the correct way, since you are using ketarin.

But the base package hasn't changed in 17 months and we could really use the checksum for automatic installs and upgrades.