### PR TITLE
Update NodeJS.install.lts Author and License

### DIFF
--- a/automatic/nodejs.install.lts/nodejs.install.nuspec
+++ b/automatic/nodejs.install.lts/nodejs.install.nuspec
@@ -4,7 +4,7 @@
     <id>nodejs.install</id>
     <title>Node JS (Install)</title>
     <version>{{PackageVersion}}</version>
-    <authors>Joyent</authors>
+    <authors>Node.js Foundation</authors>
     <owners>Rob Reynolds</owners>
     <summary>Node JS - Evented I/O for v8 JavaScript.</summary>
     <description>Node JS - Evented I/O for v8 JavaScript. Node's goal is to provide an easy way to build scalable network programs.
@@ -14,7 +14,7 @@ This package runs the official Node JS installer, resulting in Node.exe and NPM 
     <projectUrl>http://nodejs.org</projectUrl>
     <packageSourceUrl>https://github.com/ferventcoder/chocolatey-packages/</packageSourceUrl>
     <tags>nodejs node javascript admin npm</tags>
-    <licenseUrl>https://raw.github.com/joyent/node/v0.6.18/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.github.com/nodejs/node/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/ferventcoder/chocolatey-packages/02c21bebe5abb495a56747cbb9b4b5415c933fc0/icons/nodejs.png</iconUrl>
   </metadata>


### PR DESCRIPTION
Closes ferventcoder/chocolatey-packages#111 for nodejs.install.lts.

Apologies for the multiple PRs against a single issue. Working from the web client today.