### PR TITLE
(git.install) parameter to skip Windows Explorer integration

### DIFF
--- a/automatic/git.install/git.install.nuspec
+++ b/automatic/git.install/git.install.nuspec
@@ -20,8 +20,9 @@ The following package parameters can be set:
 
  * `/GitOnlyOnPath` - this puts gitinstall\cmd on path. This is also done by default if no package parameters are set.
  * `/GitAndUnixToolsOnPath` - this puts gitinstall\bin on path. This setting will override `/GitOnlyOnPath`.
- * `/NoAutoCrlf` - this setting only affects new installs, it will not override an existing `.gitconfig`. This will ensure 'Checkout as is, commit as is'
- * `/WindowsTerminal` - this makes vim use the regular Windows terminal instead of MinTTY terminal
+ * `/NoAutoCrlf` - this setting only affects new installs, it will not override an existing `.gitconfig`. This will ensure 'Checkout as is, commit as is'.
+ * `/WindowsTerminal` - this makes vim use the regular Windows terminal instead of MinTTY terminal.
+ * `/NoExplorerIntegration` - this skips the installation of Windows Explorer context menu entries.
 
 These parameters can be passed to the installer with the use of `-params`.
 For example: `-params '"/GitAndUnixToolsOnPath /NoAutoCrlf"'`.

--- a/automatic/git.install/tools/chocolateyInstall.ps1
+++ b/automatic/git.install/tools/chocolateyInstall.ps1
@@ -106,7 +106,9 @@ if ($noAutoCrlf) {
 if ($noExplorerIntegration) {
   # remove all components that start with 'ext'
   # components are documented at https://github.com/msysgit/msysgit/blob/master/share/WinGit/install.iss#L64
-  $fileArgs = $fileArgs -replace '(?<=/COMPONENTS="[^"]*)ext[^,"]*,?','' -replace ',"',''
+  $fileArgs = $fileArgs -replace '(?<=/COMPONENTS="[^"]*)ext[^,"]*,?',''
+  # remove trailing comma
+  $fileArgs = $fileArgs -replace '(?<=/COMPONENTS="[^"]*),(?=")',''
 }
 
 # Make our install work properly when running under SYSTEM account (Chef Cliet Service, Puppet Service, etc)

--- a/automatic/git/git.nuspec
+++ b/automatic/git/git.nuspec
@@ -20,7 +20,9 @@ The following package parameters can be set:
 
  * `/GitOnlyOnPath` - this puts gitinstall\cmd on path. This is also done by default if no package parameters are set.
  * `/GitAndUnixToolsOnPath` - this puts gitinstall\bin on path. This setting will override `/GitOnlyOnPath`.
- * `/NoAutoCrlf` - this setting only affects new installs, it will not override an existing `.gitconfig`. This will ensure 'Checkout as is, commit as is'
+ * `/NoAutoCrlf` - this setting only affects new installs, it will not override an existing `.gitconfig`. This will ensure 'Checkout as is, commit as is'.
+ * `/WindowsTerminal` - this makes vim use the regular Windows terminal instead of MinTTY terminal.
+ * `/NoExplorerIntegration` - this skips the installation of Windows Explorer context menu entries.
 
 These parameters can be passed to the installer with the use of `-params`.
 For example: `-params '"/GitAndUnixToolsOnPath /NoAutoCrlf"'`.


### PR DESCRIPTION
This code adds a package parameter to skip the Windows Explorer integration in the Git installation package.
I like my context menu short and prefer not to install extensions if I don't use them.

The new parameter is called `/NoExplorerIntegration`. The GUI installer installs the context menu entries by default, and this is also the default for the chocolatey package. What's new is that users can now turn them off explicitly if they want to.

![Installation Dialog](https://i.stack.imgur.com/p9bYj.jpg)

Please review the pull request and send feedback.