### PR TITLE
(dropbox) Update to package version handling

### DIFF
--- a/automatic/dropbox/tools/chocolateyInstall.ps1
+++ b/automatic/dropbox/tools/chocolateyInstall.ps1
@@ -19,8 +19,8 @@ try {
 
   $installedVersion = (getDropboxRegProps).DisplayVersion
 
-  if ($installedVersion -eq $version) {
-    Write-Host "Dropbox $version is already installed."
+  if ($installedVersion -ge $version) {
+    Write-Host "Dropbox $installedVersion is already installed."
   } else {
 
     # Download and install Dropbox


### PR DESCRIPTION
The Chocolatey package can be several versions behind the updated version from Dropbox. This will allow the package to fail gracefully; if a higher version is already installed.
@ferventcoder 