### PR TITLE
(Expresso) update FixedDownloadUrl to new MSI labeled as 3.1

### DIFF
--- a/ketarin/expresso.ketarin.xml
+++ b/ketarin/expresso.ketarin.xml
@@ -115,7 +115,7 @@
     <FileHippoId />
     <LastUpdated>2013-09-05T02:50:21.7173969+02:00</LastUpdated>
     <TargetPath>C:\Chocolatey\_work\</TargetPath>
-    <FixedDownloadUrl>http://www.ultrapico.com/ExpressoSetup3.msi</FixedDownloadUrl>
+    <FixedDownloadUrl>http://www.ultrapico.com/ExpressoSetup-3.1.msi</FixedDownloadUrl>
     <Name>expresso</Name>
   </ApplicationJob>
 </Jobs>


### PR DESCRIPTION
the new MSI is the same size as the old MSI.  
http://www.ultrapico.com/ExpressoDownload.htm Shows this full version as "Expresso 3.1 (Version 3.1.6224 - January 15, 2017*)" so I assume that the version detection will continue to work.