### PR TITLE
Upgrade MSBuild Community Tasks package to 1.5.0.235

### DIFF
--- a/manual/msbuild.communitytasks/msbuild.communitytasks.nuspec
+++ b/manual/msbuild.communitytasks/msbuild.communitytasks.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>msbuild.communitytasks</id>
     <title>MSBuild Community Tasks</title>
-    <version>1.5.0.196</version>
+    <version>1.5.0.235</version>
     <authors>Paul Welter</authors>
     <owners>Rob Reynolds</owners>
     <summary>MSBuild Community Tasks - Open Source MSBuild Tasks</summary>

--- a/manual/msbuild.communitytasks/tools/chocolateyInstall.ps1
+++ b/manual/msbuild.communitytasks/tools/chocolateyInstall.ps1
@@ -1,1 +1,1 @@
-﻿Install-ChocolateyPackage 'msbuild.communitytasks' 'msi' '/quiet' 'https://github.com/loresoft/msbuildtasks/releases/download/1.5.0.196/MSBuild.Community.Tasks.v1.5.0.196.msi'
+﻿Install-ChocolateyPackage 'msbuild.communitytasks' 'msi' '/quiet' 'https://github.com/loresoft/msbuildtasks/releases/download/1.5.0.235/MSBuild.Community.Tasks.v1.5.0.235.msi'


### PR DESCRIPTION
In this PR I upgraded choco package to latest release [1.5.0.235](https://github.com/loresoft/msbuildtasks/releases/tag/1.5.0.235).

