### PR TITLE
(synergy) free version (v1.8.8)

### DIFF
--- a/manual/synergy/synergy.nuspec
+++ b/manual/synergy/synergy.nuspec
@@ -4,12 +4,12 @@
   <metadata>
     <id>synergy</id>
     <title>synergy (Install)</title>
-    <version>1.7.6</version>
+    <version>1.8.8</version>
     <authors>Chris Schoeneman, Nick Bolton</authors>
     <owners>Rob Reynolds</owners>
     <summary>Synergy - The Virtual KVM</summary>
     <description>Synergy lets you easily share your mouse and keyboard between multiple computers on your desk, and it's Free and Open Source. Just move your mouse off the edge of one computer's screen on to another. You can even share all of your clipboards. All you need is a network connection. Synergy is cross-platform (works on Windows, Mac OS X and Linux).</description>
-    <projectUrl>http://synergy-foss.org/</projectUrl>
+    <projectUrl>https://github.com/symless/synergy</projectUrl>
     <packageSourceUrl>https://github.com/ferventcoder/chocolatey-packages/</packageSourceUrl>
     <tags>synergy virtual kvm admin</tags>
     <licenseUrl>http://www.gnu.org/licenses/old-licenses/gpl-2.0.html</licenseUrl>

--- a/manual/synergy/tools/chocolateyInstall.ps1
+++ b/manual/synergy/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName= 'synergy'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url   = "http://synergy-project.org/files/packages/synergy-v1.7.6-stable-bcb9da8-Windows-x86.msi"
-$url64 = "http://synergy-project.org/files/packages/synergy-v1.7.6-stable-bcb9da8-Windows-x64.msi"
+$url   = "https://github.com/afzaalace/synergy-stable-builds/releases/download/v1.8.8-stable/synergy-v1.8.8-stable-Windows-x86.msi"
+$url64 = "https://github.com/afzaalace/synergy-stable-builds/releases/download/v1.8.8-stable/synergy-v1.8.8-stable-Windows-x64.msi"
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
The official synergy project is now in this repo https://github.com/symless/synergy and is still free, but they don't provide binaries.

Github user afzaalace creates binaries in this other public fork https://github.com/afzaalace/synergy-stable-builds/releases.