### PR TITLE
puppet-agent version 5 automation

### DIFF
--- a/automatic/puppet-agent/tools/chocolateyinstall.ps1
+++ b/automatic/puppet-agent/tools/chocolateyinstall.ps1
@@ -1,10 +1,14 @@
 ﻿$packageArgs = @{
-  packageName   = 'puppet-agent'
-  fileType      = 'MSI'
-  url           = 'https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-{{PackageVersion}}-x86.msi'
-  url64bit      = 'https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-{{PackageVersion}}-x64.msi'
-  silentArgs    = "/qn /norestart"
-  validExitCodes= @(0, 3010, 1641)
+  packageName    = 'puppet-agent'
+  fileType       = 'MSI'
+  url            = 'https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-{{PackageVersion}}-x86.msi'
+  url64bit       = 'https://downloads.puppetlabs.com/windows/puppet5/puppet-agent-{{PackageVersion}}-x64.msi'
+  checksum       = 'a1b2c3'
+  checksum64     = 'a1b2c3'
+  checksumType   = 'sha256'
+  checksumType64 = 'sha256'
+  silentArgs     = "/qn /norestart"
+  validExitCodes = @(0, 3010, 1641)
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/automatic/puppet-agent/update.ps1
+++ b/automatic/puppet-agent/update.ps1
@@ -1,0 +1,30 @@
+import-module au
+
+$releases = 'https://downloads.puppetlabs.com/windows/puppet5/'
+
+function global:au_GetLatest {
+	$download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+
+	$regex = '.msi$'
+
+	$url = $download_page.links | ? href -match $regex | ? href -notmatch 'latest' | select -Last 2 -expand href
+	$url32 = $releases + ($url -match 'x86')
+	$url64 = $releases + ($url -match 'x64')
+
+	$version = $url -split '-' | select -Index 2
+
+	@{ Version = $version; URL32 = $url32; URL64=$url64 }
+}
+
+function global:au_SearchReplace {
+    @{
+        "tools\chocolateyInstall.ps1" = @{
+            "(url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
+            "(checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
+            "(url64bit\s*=\s*)('.*')"   = "`$1'$($Latest.URL64)'"
+            "(checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
+        }
+    }
+}
+
+update


### PR DESCRIPTION
Update chocolateyInstall.ps1 to handle checksums for 32 and 64 bit (note: Have populated the checksum values with invalid sums for this request).

Creation of update.ps1 based on coreteampackage jitsi - puppet5 download site populates the list in order from oldest to youngest which requires us to pull the last two files rather than the first two, but otherwise the functionality is the same.