### PR TITLE
(keybase) Added exit code 3010 as a valid exit code

### DIFF
--- a/manual/keybase/tools/chocolateyinstall.ps1
+++ b/manual/keybase/tools/chocolateyinstall.ps1
@@ -8,5 +8,6 @@ $packageArgs = @{
   url                    = 'https://prerelease.keybase.io/keybase_setup_386.exe'
   checksum               = '89d876b3188b44b702e7e9cbcb0290b543ea1639d01a9cbd1d0328e479399a28'
   checksumType           = 'sha256'
+  validExitCodes         = @(0, 3010)
 }
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Due to the keybase software sometimes need to reboot
and returns the exit code 3010 (Reboot needed), this change
should be added to the package.