### PR TITLE
Remove aliases from chocolateyuninstall.ps1.

### DIFF
--- a/manual/msi.template/templates/tools/chocolateyuninstall.ps1
+++ b/manual/msi.template/templates/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@
 
 $packageName = '[[PackageName]]'
 $softwareName = '[[PackageName]]*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
-$installerType = 'MSI' 
+$installerType = 'MSI'
 $silentArgs = '/qn /norestart'
 # https://msdn.microsoft.com/en-us/library/aa376931(v=vs.85).aspx
 $validExitCodes = @(0, 3010, 1605, 1614, 1641)
@@ -10,23 +10,23 @@ $validExitCodes = @(0, 3010, 1605, 1614, 1641)
 $uninstalled = $false
 # Get-UninstallRegistryKey is new to 0.9.10, if supporting 0.9.9.x and below,
 # take a dependency on "chocolatey-uninstall.extension" in your nuspec file.
-# This is only a fuzzy search if $softwareName includes '*'. Otherwise it is 
+# This is only a fuzzy search if $softwareName includes '*'. Otherwise it is
 # exact. In the case of versions in key names, we recommend removing the version
 # and using '*'.
 [array]$key = Get-UninstallRegistryKey -SoftwareName $softwareName
 
 if ($key.Count -eq 1) {
-  $key | % { 
+  $key | ForEach-Object {
     $file = "$($_.UninstallString)"
 
     if ($installerType -eq 'MSI') {
-      # The Product Code GUID is all that should be passed for MSI, and very 
-      # FIRST, because it comes directly after /x, which is already set in the 
+      # The Product Code GUID is all that should be passed for MSI, and very
+      # FIRST, because it comes directly after /x, which is already set in the
       # Uninstall-ChocolateyPackage msiargs (facepalm).
       $silentArgs = "$($_.PSChildName) $silentArgs"
 
-      # Don't pass anything for file, it is ignored for msi (facepalm number 2) 
-      # Alternatively if you need to pass a path to an msi, determine that and 
+      # Don't pass anything for file, it is ignored for msi (facepalm number 2)
+      # Alternatively if you need to pass a path to an msi, determine that and
       # use it instead of the above in silentArgs, still very first
       $file = ''
     }
@@ -43,5 +43,5 @@ if ($key.Count -eq 1) {
   Write-Warning "$key.Count matches found!"
   Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
   Write-Warning "Please alert package maintainer the following keys were matched:"
-  $key | % {Write-Warning "- $_.DisplayName"}
+  $key | ForEach-Object {Write-Warning "- $_.DisplayName"}
 }


### PR DESCRIPTION
This makes it easier on new-comers who use the templates from the VSCode Extension