### PR TITLE
Update download URLs

### DIFF
--- a/manual/webpicmd/tools/chocolateyInstall.ps1
+++ b/manual/webpicmd/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 $packageName = 'webpicmd'
 $installerType = 'msi'
 # http://forums.iis.net/t/1178551.aspx?PLEASE+READ+WebPI+direct+download+links
-$url   = 'https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_x86_en-US.msi'
-$url64 = 'https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi'
+$url   = 'https://go.microsoft.com/fwlink/?LinkId=287165'
+$url64 = 'https://go.microsoft.com/fwlink/?LinkId=287166'
 $silentArgs = "/qn /norestart"
 
 $installDir = Join-Path "$toolsDir" 'webpi'


### PR DESCRIPTION
The URLs to download webpicmd from Microsoft were 404ing. This change updates the download path to use working links.