### PR TITLE
Updated the webpicmd msi urls and version number.

### DIFF
--- a/manual/webpicmd/tools/chocolateyInstall.ps1
+++ b/manual/webpicmd/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 $packageName = 'webpicmd'
 $installerType = 'msi'
 # http://forums.iis.net/t/1178551.aspx?PLEASE+READ+WebPI+direct+download+links
-$url   = 'https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_x86_en-US.msi'
-$url64 = 'https://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi'
+$url   = 'https://download.microsoft.com/download/8/4/9/849DBCF2-DFD9-49F5-9A19-9AEE5B29341A/WebPlatformInstaller_x86_en-US.msi'
+$url64 = 'https://download.microsoft.com/download/8/4/9/849DBCF2-DFD9-49F5-9A19-9AEE5B29341A/WebPlatformInstaller_x64_en-US.msi'
 $silentArgs = "/qn /norestart"
 
 $installDir = Join-Path "$toolsDir" 'webpi'

--- a/manual/webpicmd/webpicmd.nuspec
+++ b/manual/webpicmd/webpicmd.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>webpicmd</id>
     <title>WebPI (Platform Installer) Command Line</title>
-    <version>7.1.50430.20141001</version>
+    <version>7.1.51515.0</version>
     <authors>Microsoft</authors>
     <owners>Rob Reynolds</owners>
     <summary>Web PI (Platform Installer) Command Line v5</summary>
     <description>The Microsoft Web Platform Installer (Web PI) Command Line v5 makes it easy for you to download, install, and keep up to date on the latest software components of the Microsoft Web Platform for development and application hosting on the Windows operating system. Web PI does the work of comparing the newest available components across the Microsoft Web Platform against what is already installed on your computer; you can see what is new and what you haven't yet installed. You can use Web PI to learn more about different components and install one or more components in a chained installation, with Web PI handling reboots and logging failures where applicable.
     </description>
-    <projectUrl>http://www.iis.net/learn/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release</projectUrl>
+    <projectUrl>https://docs.microsoft.com/en-us/iis/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release</projectUrl>
     <packageSourceUrl>https://github.com/ferventcoder/chocolatey-packages/</packageSourceUrl>
     <tags>webpi web pi platform installer microsoft tool</tags>
     <licenseUrl>http://www.microsoft.com/web/webpi/eula/webpi_45_en.htm</licenseUrl>


### PR DESCRIPTION
I'm attempting to install UrlRewrite2 using the webpi source.
cinst UrlRewrite2 -source webpi

It fails due to a 404 as shown in this gist when it attempts to download the webpicmd package:
Gist: https://gist.github.com/allensanborn/bc8e5903d3d42a5b86c171d1c3ef70f5
MSI that is 404ing: http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstalleramd64en-US.msi.

I checked the webpi package and it is using the fwlink to redirect to the msi and it successfully downloads and installs.
https://community.chocolatey.org/packages/webpi#files

I checked the webpicmd package and it is using a direct link to an msi that is the same url that is 404ing in the logs.
https://community.chocolatey.org/packages/webpicmd#files

The Microsoft IIS site lists these as the Web Platform Installer Command Line msi links and lists it as v5.1 despite what the page's url states...:
https://docs.microsoft.com/en-us/iis/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release

WebPI v5.1 x86: https://download.microsoft.com/download/8/4/9/849DBCF2-DFD9-49F5-9A19-9AEE5B29341A/WebPlatformInstallerx86en-US.msi
WebPI v5.1 x64: https://download.microsoft.com/download/8/4/9/849DBCF2-DFD9-49F5-9A19-9AEE5B29341A/WebPlatformInstallerx64en-US.msi

I believe the webpicmd package needs to be updated with these newer urls.